### PR TITLE
WF-62548-Add GitHub sample link in UG documentation

### DIFF
--- a/File-Formats/DocIO/Accepting-or-Rejecting-Track-Changes.md
+++ b/File-Formats/DocIO/Accepting-or-Rejecting-Track-Changes.md
@@ -139,7 +139,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 
 {% endtabs %} 
 
-You can download a complete working sample of enable track changes of the Word document from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Track-Changes/Enable-track-changes-of-Word).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Track-Changes/Enable-track-changes-of-Word).
 
 ## Accept all changes
 
@@ -232,7 +232,7 @@ document.Close();
 
 {% endtabs %}
 
-You can download a complete working sample of accepting all the tracked changes in Word document from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Track-Changes/Accept-all-changes).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Track-Changes/Accept-all-changes).
 
 By executing the above code example, it generates output Word document as follows.
 
@@ -328,7 +328,7 @@ document.Close();
 
 {% endtabs %}
 
-You can download a complete working sample of rejecting all the tracked changes in Word document from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Track-Changes/Reject-all-changes).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Track-Changes/Reject-all-changes).
 
 By executing the above code example, it generates output Word document as follows.
 
@@ -459,7 +459,7 @@ document.Close();
 
 {% endtabs %}
 
-You can download a complete working sample of accepting all the tracked changes made by the author in Word document from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Track-Changes/Accept-all-changes-made-by-author).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Track-Changes/Accept-all-changes-made-by-author).
 
 ## Reject all changes by particular reviewer
 
@@ -586,7 +586,7 @@ document.Close();
 
 {% endtabs %}
 
-You can download a complete working sample of rejecting all the tracked changes made by the author in Word document from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Track-Changes/Reject-all-changes-made-by-author).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Track-Changes/Reject-all-changes-made-by-author).
 
 ## Revision information
 
@@ -684,7 +684,7 @@ document.Close();
 
 {% endtabs %}
 
-You can download a complete working sample of getting the details about the revision information of track changes from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Track-Changes/Get-revision-information).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Track-Changes/Get-revision-information).
 
 **Frequently Asked Questions**
 

--- a/File-Formats/DocIO/Applying-Watermark.md
+++ b/File-Formats/DocIO/Applying-Watermark.md
@@ -158,7 +158,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("TextWatermark.docx", "
 
 {% endtabs %}  
 
-You can download a complete working sample of adding a text watermark to the Word document from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Watermark/Add-text-watermark).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Watermark/Add-text-watermark).
 
 ## Picture Watermark
 
@@ -222,4 +222,4 @@ document.Close()
 
 {% endtabs %}
 
-You can download a complete working sample of adding a picture watermark to the Word document from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Watermark/Add-picture-watermark).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Watermark/Add-picture-watermark).

--- a/File-Formats/DocIO/Create-Word-document-in-ASP-NET-Core.md
+++ b/File-Formats/DocIO/Create-Word-document-in-ASP-NET-Core.md
@@ -293,6 +293,8 @@ return File(stream, "application/msword", "Sample.docx");
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/ASP.NET-Core).
+
 By executing the program, you will get the **Word document** as follows.
 
 ![ASP.Net Core output Word document](ASP-NET-Core_images/GettingStartedOutput.jpg)

--- a/File-Formats/DocIO/Create-Word-document-in-ASP-NET-MVC.md
+++ b/File-Formats/DocIO/Create-Word-document-in-ASP-NET-MVC.md
@@ -282,6 +282,8 @@ document.Save("Sample.docx", FormatType.Docx, HttpContext.ApplicationInstance.Re
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/ASP.NET-MVC).
+
 By executing the program, you will get the Word document as follows.
 
 ![ASP.Net MVC output Word document](ASP-NET-MVC_images/GettingStartedOutput.jpg)

--- a/File-Formats/DocIO/Create-Word-document-in-ASP-NET.md
+++ b/File-Formats/DocIO/Create-Word-document-in-ASP-NET.md
@@ -286,6 +286,8 @@ document.Save("Sample.docx", FormatType.Docx, HttpContext.Current.Response, Http
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/ASP.NET).
+
 By executing the program, you will get the **Word document** as follows.
 
 ![ASP.Net Web output Word document](ASP-NET_images/GettingStartedOutput.jpg)

--- a/File-Formats/DocIO/Create-Word-document-in-Blazor.md
+++ b/File-Formats/DocIO/Create-Word-document-in-Blazor.md
@@ -245,7 +245,7 @@ public static class FileUtils
 
 {% endtabs %}
 
-A complete working example of how to create a Word file in Blazor Server-Side Application can be downloaded from [Create-Word-file.zip](https://www.syncfusion.com/downloads/support/directtrac/general/ze/ServerSideApplication1446629651.zip).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/Blazor/Server-side-application).
 
 By executing the program, you will get the **Word document** as follows.
 
@@ -451,7 +451,7 @@ public static class FileUtils
 
 {% endtabs %}
 
-A complete working example of how to create a Word file in Blazor Client-Side can be downloaded from [Create-Word-file.zip](https://www.syncfusion.com/downloads/support/directtrac/general/ze/ClientSideApplication2017636034.zip).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/Blazor/Client-side-application).
 
 By executing the program, you will get the **Word document** as follows.
 

--- a/File-Formats/DocIO/Create-Word-document-in-Linux.md
+++ b/File-Formats/DocIO/Create-Word-document-in-Linux.md
@@ -319,6 +319,8 @@ dotnet run
 
 ![Run the Applcation](Linux-images/Run.png)
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/Linux).
+
 By executing the program, you will get the **Word document** as follows. The output will be saved in parallel to program.cs file.
 
 ![Word document generated on Linux](Linux-images/GettingStartedOutput.jpg)

--- a/File-Formats/DocIO/Create-Word-document-in-MAUI.md
+++ b/File-Formats/DocIO/Create-Word-document-in-MAUI.md
@@ -309,7 +309,7 @@ DependencyService.Get<ISave>().SaveAndView("Sample.docx", "application/msword", 
 
 {% endtabs %}
 
-A complete working example of creating a Word document in the .NET MAUI app can be downloaded from this [link](https://www.syncfusion.com/downloads/support/directtrac/general/ze/CreateWordSample1545592917.zip).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/.NET-MAUI).
 
 By executing the program, you will get the **Word document** as follows.
 

--- a/File-Formats/DocIO/Create-Word-document-in-Mac.md
+++ b/File-Formats/DocIO/Create-Word-document-in-Mac.md
@@ -276,6 +276,8 @@ outputStream.Dispose();
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/Mac).
+
 By executing the program, you will get the **Word document** as follows. The output will be saved in bin folder.
 
 ![.Net Core output Word document](Mac-images/GettingStartedOutput.jpg)

--- a/File-Formats/DocIO/Create-Word-document-in-UWP.md
+++ b/File-Formats/DocIO/Create-Word-document-in-UWP.md
@@ -340,6 +340,8 @@ async void Save(MemoryStream streams, string filename)
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/UWP).
+
 By executing the program, you will get the Word document as follows.
 
 ![UWP output Word document](UWP_images/GettingStartedOutput.jpg)

--- a/File-Formats/DocIO/Create-Word-document-in-WPF.md
+++ b/File-Formats/DocIO/Create-Word-document-in-WPF.md
@@ -284,6 +284,8 @@ document.Save("Sample.docx");
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/WPF).
+
 By executing the program, you will get the **Word document** as follows.
 
 ![WPF output Word document](WPF_images/GettingStartedOutput.jpg)

--- a/File-Formats/DocIO/Create-Word-document-in-WinUI.md
+++ b/File-Formats/DocIO/Create-Word-document-in-WinUI.md
@@ -305,7 +305,7 @@ Save(outputStream, "Sample.docx");
 
 {% endtabs %}
 
-A complete working example of creating a Word document in the WinUI Desktop app can be downloaded from this [link](https://www.syncfusion.com/downloads/support/directtrac/general/ze/CreateWordSample295611316.zip).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/WinUI/WinUI-Desktop-app).
 
 By executing the program, you will get the **Word document** as follows.
 
@@ -607,7 +607,7 @@ using (WordDocument document = new WordDocument())
 
 {% endtabs %}
 
-A complete working example of creating a Word document in  the WinUI UWP app can be downloaded from this [link](https://www.syncfusion.com/downloads/support/directtrac/general/ze/CreateWordSample_UWP193025116.zip).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/WinUI/WinUI-UWP-app).
 
 By executing the program, you will get the **Word document** as follows.
 

--- a/File-Formats/DocIO/Create-Word-document-in-Windows-Forms.md
+++ b/File-Formats/DocIO/Create-Word-document-in-Windows-Forms.md
@@ -298,6 +298,8 @@ document.Save("Sample.docx");
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/Windows-Forms).
+
 By executing the program, you will get the **Word document** as follows.
 
 ![Windows Forms output Word document](Windows-Forms_images/GettingStartedOutput.jpg)

--- a/File-Formats/DocIO/Create-Word-document-in-Xamarin.md
+++ b/File-Formats/DocIO/Create-Word-document-in-Xamarin.md
@@ -412,6 +412,8 @@ Download the helper files from this [link](https://www.syncfusion.com/downloads/
 
 Compile and execute the application. Now this application **creates a Word document**.
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/Xamarin).
+
 By executing the program, you will get the Word document as follows.
 
 ![Xamarin output Word document](Xamarin_images/GettingStartedOutput.jpg)

--- a/File-Formats/DocIO/Getting-Started.md
+++ b/File-Formats/DocIO/Getting-Started.md
@@ -167,7 +167,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}
 
-You can download a complete working sample of creating a new Word document from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/Create-Word-document).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/Create-Word-document).
 
 ## Creating a new Word document from scratch with basic elements
 
@@ -954,7 +954,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView(outputFileName, "applic
 
 {% endtabs %}  
 
-You can download a complete working sample of creating a new Word document with basic elements from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/Create-Word-with-basic-elements).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Getting-Started/Create-Word-with-basic-elements).
 
 The resultant Word document looks as follows.
 

--- a/File-Formats/DocIO/Loading-and-Saving-document.md
+++ b/File-Formats/DocIO/Loading-and-Saving-document.md
@@ -564,7 +564,7 @@ You can download a complete working sample from [GitHub](https://github.com/Sync
 
 ## Sending to a client browser
 
-You can save and send the document to a client browser from a web site or web application by invoking the following shown overload of `Save` method.  This method explicitly makes use of an instance of [HttpResponse](https://msdn.microsoft.com/en-us/library/system.web.httpresponse(v=vs.110).aspx#) as its parameter in order to stream the document to client browser. So this overload is suitable for web application that references System.Web assembly.
+You can save and send the document to a client browser from a web site or web application by invoking the following shown overload of `Save` method.  This method explicitly makes use of an instance of [HttpResponse](https://docs.microsoft.com/en-us/dotnet/api/system.web.httpresponse?view=netframework-4.8) as its parameter in order to stream the document to client browser. So this overload is suitable for web application that references System.Web assembly.
 
 {% tabs %}  
 

--- a/File-Formats/DocIO/Loading-and-Saving-document.md
+++ b/File-Formats/DocIO/Loading-and-Saving-document.md
@@ -125,6 +125,8 @@ document.Open(assembly.GetManifestResourceStream("XamarinFormsApp1.Assets.Test.d
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Read-and-Save-document/Open-and-save-Word-document).
+
 ## Opening an existing document from Stream
 
 You can open an existing document from stream by using either the overloads of `Open` methods or the constructor of `WordDocument` class
@@ -222,6 +224,8 @@ using (WordDocument document = new WordDocument())
 {% endhighlight %}
 
 {% endtabs %} 
+
+You can download a complete working sample from Stream from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Read-and-Save-document/Open-and-save-Word-document).
 
 ## Opening an Encrypted Word document
 
@@ -365,6 +369,8 @@ document.OpenReadOnly("Template.docx", Syncfusion.DocIO.FormatType.Docx, "passwo
 
 {% endtabs %} 
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Read-and-Save-document/Open-read-only-Word-document).
+
 ## Saving a Word document to file system
 
 You can save the created or manipulated Word document to file system using `Save` method of `WordDocument` class. When you do not provide the format type, then the document is saved in Word 97-2003 (*.doc) format.
@@ -449,6 +455,8 @@ document.Close();
 {% endhighlight %}
 
 {% endtabs %} 
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Read-and-Save-document/Open-and-save-Word-document).
 
 ## Saving a Word document to Stream
 
@@ -552,6 +560,8 @@ using (WordDocument document = new WordDocument())
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Read-and-Save-document/Open-and-save-Word-document).
+
 ## Sending to a client browser
 
 You can save and send the document to a client browser from a web site or web application by invoking the following shown overload of `Save` method.  This method explicitly makes use of an instance of [HttpResponse](https://msdn.microsoft.com/en-us/library/system.web.httpresponse(v=vs.110).aspx#) as its parameter in order to stream the document to client browser. So this overload is suitable for web application that references System.Web assembly.
@@ -611,6 +621,8 @@ return File(stream, "application/msword", "Result.docx");
 {% endhighlight %}
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Read-and-Save-document/Send-Word-to-client-browser).
 
 ## Closing a document
 
@@ -719,3 +731,5 @@ using (WordDocument document = new WordDocument())
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Read-and-Save-document/Open-and-save-Word-document).

--- a/File-Formats/DocIO/Working-With-Content-Controls.md
+++ b/File-Formats/DocIO/Working-With-Content-Controls.md
@@ -1,6 +1,6 @@
 ---
 title: Working with Content Controls | DocIO | Syncfusion
-description: This section illustrates how to work with Content Controls
+description: This section illustrates how to work with Content Controls in the Word document using Syncfusion Word library (Essential DocIO)
 platform: file-formats
 control: DocIO
 documentation: UG

--- a/File-Formats/DocIO/Working-With-Content-Controls.md
+++ b/File-Formats/DocIO/Working-With-Content-Controls.md
@@ -168,6 +168,8 @@ document.Close();
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Content-Controls/Block-content-control).
+
 ### Inline Content Control
 
 You can add content control as a child to a paragraph using the inline content control. You can add text, pictures, fields or other paragraph items into the inline content control. Refer to the following code.
@@ -286,6 +288,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 document.Close();
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Content-Controls/Inline-content-control).
 
 N> Currently, DocIO does not support RowContentControl and CellContentControl.
 
@@ -514,6 +518,8 @@ document.Close();
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Content-Controls/Content-control-properties).
+
 ## Why Content Control?
 
 The content controls have the following three major use cases:
@@ -697,6 +703,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 document.Close();
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Content-Controls/Protect-content-control).
 
 ### Form Filling
 
@@ -2092,6 +2100,8 @@ document.Close();
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Content-Controls/Create-form-in-Word-document).
+
 You can also fill the forms using the DocIO. Refer to the following code example.
 
 Form filling:
@@ -2571,6 +2581,8 @@ document1.Close();
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Content-Controls/Fill-form-in-Word-document).
+
 ### Data Binding with Content Controls (XML Mapping)
 
 Word allows you to store XML data, named *custom XML parts*, in a Word document. You can control the display of this data by binding content controls to elements in a custom XML part. When you open the Word document, the content controls display the values of the XML elements. Any changes that you make to the text in the content controls are saved in the custom XML part (two-way data binding). Refer to the following code sample to map custom XML parts to content control.
@@ -2748,6 +2760,8 @@ document.Close();
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Content-Controls/Xml-mapping).
+
 ## Types of Content Controls
 
 The following types of content controls can be created by using the Essential DocIO.
@@ -2914,6 +2928,8 @@ document.Close();
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Content-Controls/Rich-text-content-control).
+
 ### Plain Text
 
 A plain text content control contains text and cannot contain other items, such as tables, pictures, or other content controls. Refer to the following code to add plain text content control.
@@ -3032,6 +3048,8 @@ document.Close();
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Content-Controls/Plain-text-content-control).
+
 ### Check Box
 
 A check box content control provides a UI that represents a binary state: checked or unchecked. Default state for check box is unchecked. Refer to the following code to add check box content control.
@@ -3135,6 +3153,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 document.Close();
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Content-Controls/Check-box-content-control).
 
 ### Date picker
 
@@ -3284,6 +3304,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 document.Close();
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Content-Controls/Date-picker-content-control).
 
 ### Drop-Down List and Combo Box
 
@@ -3597,6 +3619,8 @@ document.Close();
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Content-Controls/Drop-down-list-and-combo-box).
+
 ### Picture
 
 A picture content control displays an image. Refer to the following code to add new picture content control.
@@ -3726,5 +3750,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 document.Close();
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Content-Controls/Picture-content-control).
 
 N> In the above-mentioned code samples, for Xamarin platforms the document is saved as stream only. To save the stream to file kindly refer code sample [here](https://help.syncfusion.com/file-formats/docio/xamarin#save-the-document#).

--- a/File-Formats/DocIO/Working-with-Charts.md
+++ b/File-Formats/DocIO/Working-with-Charts.md
@@ -325,6 +325,8 @@ using (WordDocument document = new WordDocument())
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Charts/Create-chart-from-scratch).
+
 ## Creating a Chart from Excel file
 
 The chart data can be set through the object array or can be loaded from the excel stream. The specific range of the data from the excel file can be used to set chart data. 
@@ -498,6 +500,8 @@ using (WordDocument document = new WordDocument())
 }
 {% endhighlight %}
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Charts/Create-chart-from-Excel-file).
 
 ## Creating Custom Charts
 
@@ -770,6 +774,8 @@ using (WordDocument document = new WordDocument())
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Charts/Create-custom-chart).
+
 ## Refreshing the Chart
 
 The chart may not have the data in the referred excel file instead it may represent some other data. For those charts to have the excel data, it should be refreshed. 
@@ -875,6 +881,8 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 {% endhighlight %}
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Charts/Refresh-chart-data).
 
 ## Modifying the Chart data
 
@@ -999,6 +1007,8 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 {% endhighlight %}
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Charts/Modify-an-existing-chart-data).
 
 ## Customizing the Chart & its elements
 
@@ -1273,6 +1283,8 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 {% endhighlight %}
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Charts/Modify-appearance-of-existing-chart).
 
 ### Modifying Plot Area and Legend
 
@@ -1560,6 +1572,8 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 {% endhighlight %}
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Charts/Modify-plot-area-and-legend-of-chart).
 
 ### Positioning Chart Elements
 
@@ -2040,6 +2054,8 @@ public class BarChartData
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Charts/Positioning-chart-elements).
+
 ## Applying 3D Formats
 
 Essential DocIO allows to modify the side wall, back wall, floor of the 3D chart. The following code snippet illustrates how to apply properties for side wall, floor and back wall of a 3D chart.
@@ -2166,6 +2182,8 @@ document.Close()
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Charts/Applying-3D-formats).
+
 ## Removing Chart
 
 The following code example illustrates how to remove the chart from the document.
@@ -2287,6 +2305,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Charts/Remove-chart-from-Word-document).
+
 ## Convert chart to image
 
 You can convert the chart in Word document as image using the `SaveAsImage` method in ChartToImageConverter.
@@ -2356,6 +2376,8 @@ wordDocument.Close()
 //DocIO supports chart to image conversion in Windows Forms, WPF, ASP.NET and ASP.NET MVC platform alone.
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Charts/Convert-chart-to-image).
 
 N> 1. To convert chart in Word document as image, it is need to refer chart conversion related [assemblies](https://help.syncfusion.com/file-formats/docio/assemblies-required#converting-charts) or [NuGet packages](https://help.syncfusion.com/file-formats/docio/nuget-packages-required#converting-charts).
 N> 2. The ChartToImageConverter is supported from .NET Framework 4.0 onwards.

--- a/File-Formats/DocIO/Working-with-Macros.md
+++ b/File-Formats/DocIO/Working-with-Macros.md
@@ -1,11 +1,11 @@
 ---
 title: Working with Macros | DocIO | Syncfusion
-description: This section illustrates how to load and save a macro enabled documents
+description: This section illustrates how to load and save a macro enabled documents using Syncfusion Word library (Essential DocIO)
 platform: file-formats
 control: DocIO
 documentation: UG
 ---
-# Working with Macros
+# Working with Macros in Word document
 
 Macro is a way to automate the tasks that you perform repeatedly. It is a saved sequence of commands or keyboard strokes that can be recalled with a single command or keyboard stroke. 
 

--- a/File-Formats/DocIO/Working-with-Macros.md
+++ b/File-Formats/DocIO/Working-with-Macros.md
@@ -131,6 +131,8 @@ End Function
 
 {% endtabs %} 
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Macros/Open-and-save-macro-enabled-document).
+
 The following code example illustrates how to remove the macros present in the document by using `RemoveMacros` method.
 
 {% tabs %}  
@@ -218,3 +220,5 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Macros/Remove-macros-in-document).

--- a/File-Formats/DocIO/Working-with-Mathematical-Equation.md
+++ b/File-Formats/DocIO/Working-with-Mathematical-Equation.md
@@ -195,7 +195,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of adding an accent mark to the equation from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Add-an-accent-mark-to-the-equation).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Add-an-accent-mark-to-the-equation).
 
 ### Bar
 
@@ -331,7 +331,7 @@ document.Close();
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of adding a bar to the equation from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Add-bar-to-the-equation).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Add-bar-to-the-equation).
 
 ### Box
 
@@ -553,7 +553,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of adding a box to the equation from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Add-box-to-the-equation).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Add-box-to-the-equation).
 
 ### Border box
 
@@ -765,7 +765,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of adding a border box to the equation from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Add-border-box-to-the-equation).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Add-border-box-to-the-equation).
 
 ### Delimiter
 
@@ -941,7 +941,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of adding delimiter to the equation from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Add-delimiter-to-the-equation).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Add-delimiter-to-the-equation).
 
 ### Equation array
 
@@ -1147,7 +1147,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of creating an array of equations from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-an-array-of-equations).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-an-array-of-equations).
 
 ### Fraction
 
@@ -1313,7 +1313,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of creating a fraction equation from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-fraction-equation).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-fraction-equation).
 
 ### Function
 
@@ -1474,7 +1474,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of creating a function from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-trigonometric-function).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-trigonometric-function).
 
 ### Group character
 
@@ -1640,7 +1640,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of creating an equation with grouping character from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Equation-with-grouping-character).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Equation-with-grouping-character).
 
 ### Limit
 
@@ -1844,7 +1844,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of creating limit equation from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-limit-equation).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-limit-equation).
 
 ### Matrix
 
@@ -2209,7 +2209,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of creating a matrix equation from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-matrix-equation).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-matrix-equation).
 
 ### N-Array
 
@@ -2426,7 +2426,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of creating a summation with limits from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-n-array-equation).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-n-array-equation).
 
 ### Radical
 
@@ -2589,7 +2589,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of creating a radical equation from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-radical-equation).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-radical-equation).
 
 ### Phantom
 
@@ -2802,7 +2802,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of creating a phantom equation from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-phantom-equation).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-phantom-equation).
 
 ### SubSuperscript
 
@@ -2975,7 +2975,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of creating a superscript equation from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-superscript-equation).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Create-superscript-equation).
 
 ### Left SubSuperscript
 
@@ -3154,7 +3154,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of adding superscript and subscript on the left side of the equation from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Superscript-and-subscript-on-left).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Superscript-and-subscript-on-left).
 
 ### Right SubSuperscript
 
@@ -3342,7 +3342,7 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of adding superscript and subscript on the right side of the equation from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Superscript-and-subscript-on-right).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Superscript-and-subscript-on-right).
 
 ## Modify existing equation
 
@@ -3542,7 +3542,7 @@ Xamarin.Forms.DependencyService.Get&lt;ISave&gt;().SaveAndView("Sample.docx", "a
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample of modifying an existing mathematical equation in the Word document from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Modify-an-existing-equation).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mathematical-Equation/Modify-an-existing-equation).
 
 By executing the above code example, it generates output Word document as follows.
 ![Resultant output Word document](WorkingwithMathematicalEquation_images/EditedEquation.png)

--- a/File-Formats/DocIO/Working-with-Paragraph.md
+++ b/File-Formats/DocIO/Working-with-Paragraph.md
@@ -120,6 +120,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Add-paragraph).
+
 The following code example illustrates how to modify an existing paragraph.
 
 {% tabs %}  
@@ -263,6 +265,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Modify-an-existing-paragraph).
+
 ## Applying paragraph formatting
 
 As in the Microsoft Word, DocIO provides support for all the paragraph formatting options such as line spacing, indentation, spacing before and after, keep follow, and more. The following code example explains how to apply formatting to a paragraph.
@@ -397,6 +401,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Apply-paragraph-formatting).
+
 ### Paragraph style  
 
 Paragraph style contains definition for both font (text) and paragraph formatting that can be applied to the contents of an entire paragraph. DocIO supports various pre-defined styles and also provides ability to create custom paragraph styles.
@@ -507,6 +513,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Apply-paragraph-style).
 
 ### Custom paragraph style  
 
@@ -660,6 +668,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Create-custom-paragraph-style).
+
 ### Tab stop  
 
 A tab stop is a horizontal position that is set for aligning text of the paragraph.  A tab character causes the carriage to go to the next tab stop.
@@ -786,6 +796,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Add-tab-stop).
+
 ### RTL paragraph
 
 You can set RTL (Right-to-left) direction to the paragraph in a Word document. The following code example shows how to set RTL (Right-to-left) for a paragraph in Word document.
@@ -906,6 +918,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 
 {% endtabs %}   
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/RTL-paragraph).
+
 ## Working with Text 
 
 Text within a paragraph is represented by one or more instances of the `WTextRange`. Each `WTextRange` instance can have its own font (text) formatting.  
@@ -1019,6 +1033,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Append-text-to-paragraph).
 
 Text in the paragraph can be modified or replaced with a new text. This can be achieved by iterating through the paragraph items.
 
@@ -1155,6 +1171,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Replace-text-of-a-text-range).
 
 Text formatting enhances the appearance of text in the document. Text formatting includes font size, font color, font name, bold, italic, underline, etc. 
 
@@ -1413,6 +1431,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Apply-formatting-to-text).
+
 ## Working with Images
 
 DocIO provides support for both inline and absolute positioned images. 
@@ -1534,6 +1554,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %} 
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Add-image).
 
 ### Replace image
 
@@ -1696,6 +1718,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %} 
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Replace-image).
+
 ### Remove image
 
 Images can be removed from the document by removing it from the paragraph items. 
@@ -1841,6 +1865,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Remove-image).
 
 ### Format and rotate images
 
@@ -2056,6 +2082,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %} 
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Format-and-rotate-image).
+
 ### Find an image by title 
 
 An Image with a specific title can be retrieved by iterating the paragraph items that can be used for further manipulations.
@@ -2239,6 +2267,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %} 
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Find-an-image-by-title).
 
 ### Add Image caption 
 
@@ -2470,6 +2500,8 @@ document.Close();
 
 {% endtabs %} 
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Add-image-caption).
+
 By executing the above code example, it generates output Word document as follows.
 
 ![Output of Word document with Image caption](WorkingWithImages_images/ImageCaption.png)
@@ -2646,6 +2678,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Simple-bulleted-list).
+
 The following code example explains how to create a simple numbered list.
 
 {% tabs %} 
@@ -2810,6 +2844,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Simple-numbered-list).
 
 The following code example explains how to create a multilevel bulleted list.
 
@@ -2996,6 +3032,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Multilevel-bulleted-list).
+
 The following code example explains how to create multilevel numbered list.
 
 {% tabs %}  
@@ -3180,6 +3218,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %}
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Multilevel-numbered-list).
 
 The list levels can be incremented or decremented by using the `IncreaseIndentLevel` and `DecreaseIndentLevel` methods respectively. The following code example explains how to increase or decrease the list indent levels.
 
@@ -3400,6 +3440,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Increase-or-decrease-list-indent).
 
 The following code example explains how to create user defined list styles.
 
@@ -3625,6 +3667,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/User-defined-numbered-list).
 
 The following code example explains how to create numbered list with prefix from previous level.
 
@@ -3898,6 +3942,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/List-with-prefix-from-previous-level).
+
 The following code example illustrates how to create a user defined bulleted list style.
 
 {% tabs %}  
@@ -4168,6 +4214,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %} 
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/User-defined-bulleted-list).
+
 ### Get list value
 
 You can get the string that represents the appearance of **list value of the paragraph** in the Word document using the `ListString` API. 
@@ -4262,6 +4310,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 //https://help.syncfusion.com/file-formats/docio/create-word-document-in-xamarin#helper-files-for-xamarin
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Get-list-value).
 
 N> For a picture bulleted list, the `ListString` API is not valid and it will return an empty string.
 
@@ -4381,7 +4431,9 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
- 
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Add-web-link).
+
 The following code example illustrates how to add an email link.
 
 {% tabs %} 
@@ -4487,6 +4539,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Add-an-email-link).
+
 The following code example explains how to add a file hyperlink.
 
 {% tabs %}  
@@ -4591,7 +4645,9 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
-  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Add-file-hyperlink).
+
 The following code example explains how to add a bookmark hyperlink.
 
 {% tabs %}  
@@ -4727,6 +4783,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Add-bookmark-hyperlink).
+
 The display content for the Hyperlinks can also be an image that may redirect to some other contents.
 
 The following code example explains how to add image hyperlink.
@@ -4853,6 +4911,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Add-image-hyperlink).
 
 The following code example explains how to modify the URL of an existing hyperlink.
 
@@ -5017,7 +5077,9 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
-  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Modify-url-of-hyperlink).
+
 ## Working with symbols
 
 Symbols are used to add contents such as currencies, numbers, punctuations, etc. DocIO represents symbols with `WSymbol` instance. Each symbol can be identified with their character codes.
@@ -5119,6 +5181,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Add-symbols).
 
 The following code example explains how to modify an existing symbol.
 
@@ -5284,6 +5348,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Modify-an-existing-symbol).
 
 ## Appending breaks
 
@@ -5466,6 +5532,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Append-breaks).
+
 ## Working with OLE objects
 
 OLE (Object Linking and Embedding) objects allow embedding and linking to documents and other objects. It allows the content of one program to be used in a Word document. The Objects can be inserted in the following two ways:
@@ -5601,6 +5669,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Add-ole-object).
 
 ### Extract OLE Objects from Word document
 
@@ -6069,6 +6139,8 @@ private static void ExtractOLEObject(WordDocument document)
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Extract-ole-object).
+
 ### Remove OLE Objects from Word document
   
 The following code example explains how to remove OLE objects from the document.  
@@ -6312,7 +6384,8 @@ private static void RemoveOLEObject(WordDocument document)
 
 {% endtabs %}  
   
-  
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Remove-ole-object).
+
 ## Working with Text Box
 
 Text box contains a group of textual and graphical contents. DocIO supports to create and manipulate the text box and its formatting by using the `WTextBox` instance.
@@ -6454,6 +6527,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Add-text-box).
 
 ### Format and rotate text box  
 
@@ -6668,3 +6743,5 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Format-and-rotate-text-box).

--- a/File-Formats/DocIO/Working-with-Sections.md
+++ b/File-Formats/DocIO/Working-with-Sections.md
@@ -97,6 +97,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Sections/Add-sections-in-Word-document).
+
 You can add the multiple sections into the document. When you add more than one section into the word document, the section starts from the next page by default.
 
 You can also add a new section that starts on a same page by specifying the `BreakCode` as shown in following code example.
@@ -234,6 +236,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %} 
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Sections/Add-continuous-sections-in-Word).
+
 ## Specifying Page Properties
 
 Each section has its own page setup properties such as page size, orientation, margins, borders, and more. 
@@ -365,7 +369,9 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
- 
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Sections/Page-setup-properties).
+
 ## Creating Multi-column document
 
 You can split the contents into two or more columns by specifying the column width and spacing between columns.
@@ -568,6 +574,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %} 
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Sections/Create-multi-column-document).
+
 ## Creating document with different page settings
 
 You can prefer to have more sections in a Word document when you need to have different page settings or headers and footers for a specific set of contents. The following code example illustrates how to create a Word document with multiple sections whose page orientation are portrait and landscape respectively.
@@ -742,7 +750,9 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}
-   
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Sections/Document-with-different-page-settings).
+ 
 ## Working with Headers and Footers
 
 Header and footer also represent the group of paragraphs and tables that occur at the top and bottom of the page respectively. Header and footer may vary for each section. The following are the types of Headers/Footers:
@@ -921,6 +931,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Sections/Simple-headers-and-footers).
 
 You can have a specific header and footer contents for the first page in a Word document. The following code illustrates the same. 
 
@@ -1129,6 +1141,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %}
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Sections/Header-and-footers-for-first-page).
 
 A Word document can have different header and footer for odd and even pages.
 
@@ -1339,6 +1353,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Sections/Odd-and-even-page-header-footer).
 
 You can use the previous section header and footer for the current section by using `LinkToPrevious` property.
 
@@ -1560,6 +1576,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Sections/Link-previous-section).
+
 ### Remove Headers and Footers
 
 You can remove the headers and footers from an existing Word document. The following code example explains how to remove the headers and footers from an existing Word document.
@@ -1707,6 +1725,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Sections/Remove-headers-and-footers).
 
 ## Adding Page Numbers
 
@@ -2219,6 +2239,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Sections/Add-page-number-in-footer).
+
 ## Removing a Section
 
 The following code example illustrates how to remove a particular section from the Word document
@@ -2299,6 +2321,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %} 
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Sections/Remove-section-from-document).
 
 N> The Word document is a flow document in which contents will not be preserved page by page; instead the contents will be preserved sequentially section by section. Each section may extend to various pages based on its contents like table, text, images etc.
 N> Word viewer/editor renders the contents of the Word document page by page dynamically when opened for viewing or editing and this page wise rendered information will not be preserved in the document level as per the Word file format specification.

--- a/File-Formats/DocIO/Working-with-Shapes.md
+++ b/File-Formats/DocIO/Working-with-Shapes.md
@@ -192,6 +192,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Shapes/Add-shapes-in-Word).
+
 ### Format shapes
 
 Shape can have formatting such as line color, fill color, positioning, wrap formats, etc. The following code example illustrates how to apply formatting options for shape.
@@ -377,6 +379,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Shapes/Format-shapes).
+
 ### Rotate shapes
 
 You can rotate the shape and also apply flipping (horizontal and vertical) to it. The following code example explains how to rotate and flip the shape.
@@ -516,6 +520,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Shapes/Rotate-shapes).
 
 ## Grouping shapes
 
@@ -882,6 +888,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Shapes/Add-group-shape-in-Word).
 
 The following code example illustrates how to add collection of shapes or images as a group shape in Word document.
 
@@ -1436,6 +1444,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Shapes/Collection-of-shapes-into-group-shape).
+
 ### Nested group shapes
 
 The following code example illustrates how to group the nested group shapes as a group shape in Word document.
@@ -1908,6 +1918,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Shapes/Add-nested-group-shapes).
+
 ## Ungrouping shapes
 
 You can ungroup the group shapes in the Word document to preserve each shape as individual item.
@@ -2045,3 +2057,5 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Shapes/Ungroup-shapes).

--- a/File-Formats/DocIO/Working-with-Tables.md
+++ b/File-Formats/DocIO/Working-with-Tables.md
@@ -273,6 +273,8 @@ document.Close();
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Create-simple-table).
+
 The following code example illustrates how to create a simple table by dynamically adding rows.
 
 {% tabs %} 
@@ -661,6 +663,8 @@ document.Close();
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Dynamic-table-by-adding-rows).
+
 ## Nested Table 
 
 You can create a nested table by adding a new table into a cell. The following code example illustrates how to add a table into a cell.
@@ -896,6 +900,8 @@ document.Close();
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Create-nested-table).
+
 ## Align text within a table
 
 You can iterate the cells within a table and align text for each cell. Find more information about iterating the cells from [here](https://help.syncfusion.com/file-formats/docio/working-with-tables#iterating-through-table-elements)
@@ -957,6 +963,8 @@ private void AlignCellContentForTable(WTable table, Syncfusion.DocIO.DLS.Horizon
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Align-text-within-a-table).
 
 ## Apply formatting to Table, Row and Cell
 
@@ -1230,6 +1238,8 @@ document.Close();
 {% endhighlight %} 
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Apply-table-formatting).
 
 ### Applying cell formatting
   
@@ -1518,6 +1528,8 @@ document.Close();
 
 {% endtabs %} 
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Apply-cell-formatting).
+
 ### Resize table
 
 You can automatically resize the table cell to fit its contents based on the given **autofit options** such as `FitToContent`, `FitToWindow`, `FixedColumnWidth`. 
@@ -1668,6 +1680,8 @@ document.Close();
 {% endhighlight %}
 {% endtabs %} 
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Resize-table).
+
 N> In ASP.NET Core, UWP, and Xamarin platforms, to apply autofit for table in a Word document we recommend you to use Word to PDF [assemblies](https://help.syncfusion.com/file-formats/docio/assemblies-required#converting-word-document-to-pdf) or [NuGet](https://help.syncfusion.com/file-formats/docio/nuget-packages-required#converting-word-document-to-pdf) packages as a reference in your application.
 
 ### Working with Table Style
@@ -1760,6 +1774,8 @@ document.Close();
 {% endhighlight %}   
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Apply-built-in-table-style).
 
 ### Table style options
 
@@ -1910,6 +1926,8 @@ document.Close();
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Table-style-options).
 
 ### Custom table style
 
@@ -2098,7 +2116,9 @@ document.Close();
 {% endhighlight %}
 
 {% endtabs %}  
- 
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Apply-custom-table-style).
+
 ## Merging cells vertically and horizontally
 
 You can combine two or more table cells located in the same row or column into a single cell.
@@ -2194,6 +2214,8 @@ document.Close();
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Apply-horizontal-merge-to-cells).
+
 The following code example illustrates how to apply vertical merge to specified range of rows in a specified column.
 
 {% tabs %}  
@@ -2284,6 +2306,8 @@ document.Close();
 {% endhighlight %} 
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Apply-vertical-merge-to-cells).
 
 The following code example illustrate how to create a table that contains horizontal merged cells.
 
@@ -2421,6 +2445,8 @@ document.Close();
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Create-horizontal-merged-cells).
+
 The following code example illustrates how to create a table with vertical merged cells.
 
 {% tabs %} 
@@ -2556,7 +2582,9 @@ document.Close();
 {% endhighlight %}
 
 {% endtabs %}  
-  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Create-vertical-merged-cells).
+
 ## Specifying table header row to repeat on each page
 
 You can specify one or more rows in a table to be repeated as header row at the top of each page, when the table spans across multiple pages. 
@@ -2706,6 +2734,8 @@ document.Close();
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Create-table-with-header-row).
+
 ## Keeping rows from breaking across pages
 
 You can enable or disable the table row content to split across multiple pages, when the row contents do not fit in a previous page.
@@ -2799,7 +2829,9 @@ document.Close();
 {% endhighlight %}  
 
 {% endtabs %} 
-  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Disable-row-to-break-across-pages).
+
 ## Iterating through table elements
 
 The following code example illustrates how to iterate through the table and apply back color to a particular cell.
@@ -2949,6 +2981,8 @@ document.Close();
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Iterating-through-table-elements).
+
 ## Removing the table
 
 You can remove a table from a text body by its instance or by its index position in the text body item collection. The following code example shows how to remove a table in Word document.
@@ -3049,6 +3083,8 @@ document.Close();
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Remove-table).
+
 ## Removing the table rows
 
 You can remove a particular table row from a table rows collection by its instance or by its index position in the collection. The following code example shows how to remove a particular row from table in the Word document.
@@ -3148,3 +3184,5 @@ document.Close();
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Tables/Remove-particular-row-from-table).


### PR DESCRIPTION
Kindly review the below merge request and let me know your feedback.

<table>
<tr>
<td>
Task Link
</td>
<td>
<a href="https://syncfusion.atlassian.net/browse/WF-62548">https://syncfusion.atlassian.net/browse/WF-62548</a>
</td>
</tr>
<tr>
<td>
Description
</td>
<td>
Add GitHub sample link in UG documentation.
</td>
</tr>
<tr>
<td>
Changes done
</td>
<td>
Added GitHub sample link in UG documentation in below pages, <br/>

- Charts
- Content-Controls
- Getting-Started
- Macros
- Mathematical-Equation
- Paragraphs
- Read-and-Save-document
- Sections
- Shapes
- Tables
- Track-Changes
- Watermark

</td>
</tr>
</table>