### PR TITLE
WF-62692-Add UG documentation changes for GitHub link

### DIFF
--- a/File-Formats/DocIO/Getting-Started.md
+++ b/File-Formats/DocIO/Getting-Started.md
@@ -1267,6 +1267,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("GettingStartedSample.d
 
 {% endtabs %} 
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Mail-merge-with-string-arrays).
+
 The resultant Word document look as follows.
 
 ![Performing Mail merge output document](GettingStarted_images/GettingStarted_img3.jpeg)
@@ -1639,6 +1641,8 @@ public class Employee
 {% endhighlight %} 
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Mail-merge-with-.NET-objects).
 
 The resultant document looks as follows.
 

--- a/File-Formats/DocIO/Working-with-Fields.md
+++ b/File-Formats/DocIO/Working-with-Fields.md
@@ -139,6 +139,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Fields/Add-field-in-Word-document).
+
 ## Formatting fields
 
 You can format the field instances added to the Word document by iterating the items from field start to end.
@@ -285,7 +287,9 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Template.docx", "appli
 {% endhighlight %}
 
 {% endtabs %}
-   
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Fields/Format-fields).
+
 ## Updating fields
 
 Field updating engine calculates the resultant value based on the field code information and updates the field result with a new value. You can update the following fields by using DocIO:
@@ -386,6 +390,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 {% endhighlight %}
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Fields/Update-fields-in-document).
 
 ## IF field
 
@@ -544,7 +550,9 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 
 {% endtabs %} 
-  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Fields/IF-field).
+
 ## Document variables
 
 The DocVariable field displays the value of a specified document variable in the Word document. The document variables can be added or modified using the `Variables` property of `WordDocument` class.
@@ -685,7 +693,9 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 
 {% endtabs %}
-  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Fields/Document-variables).
+
 ## Cross reference
 
 A cross-reference refers to an item that appears in another location in a document. You can create cross-reference to bookmarks in a document by using the `AppendCrossReference` method of `WParagraph` class.
@@ -849,6 +859,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Fields/Cross-reference).
+
 ## Unlink fields
 
 You can replace the field with its most recent result in the Word document by unlinking the field using the `Unlink` API. When you unlink a field, its current result is converted to text or a graphic and can no longer be updated automatically.
@@ -975,6 +987,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Fields/Unlink-fields).
 
 N>  XE (Index Entry) fields cannot be unlinked.
 
@@ -1257,6 +1271,8 @@ private WordDocument CreateDocument()
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Fields/Apply-number-format-for-SEQ-field).
+
 By executing the above code example, it generates output Word document as follows.
 
 ![Output document after applied Number format for SEQ field](WorkingWithFields_images/SEQField_NumberFormat.png)
@@ -1395,6 +1411,8 @@ document.Close();
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Fields/Refer-bookmark-in-SEQ-field).
 
 By executing the above code example, it generates output Word document as follows.
 
@@ -2042,6 +2060,8 @@ private WordDocument CreateDocument()
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Fields/Reset-numbering-for-SEQ-field).
+
 By executing the above code example, it generates output Word document as follows.
 
 ![Output of reset numbering in SEQ field](WorkingWithFields_images/SEQField_ResetNumbering.png)
@@ -2446,6 +2466,8 @@ private WordDocument CreateDocument()
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Fields/Repeat-nearest-number-of-SEQ-field).
+
 By executing the above code example, it generates output Word document as follows.
 
 ![Output of repeating Nearest number of SEQ field](WorkingWithFields_images/SEQField_RepeatNearestNumber.png)
@@ -2835,6 +2857,8 @@ private WordDocument CreateDocument()
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Fields/Hide-SEQ-field-result).
+
 By executing the above code example, it generates output Word document as follows.
 
 ![Output after hiding the sequence field](WorkingWithFields_images/SEQField_Hide.png)
@@ -2934,3 +2958,5 @@ document.Close();
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Fields/Insert-next-sequence-number).

--- a/File-Formats/DocIO/Working-with-Word-document.md
+++ b/File-Formats/DocIO/Working-with-Word-document.md
@@ -2232,7 +2232,7 @@ Please download the helper files from the following link to save the stream as a
 
 {% endtabs %} 
 
-You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Remove-particular-style-from-documents).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Remove-particular-style-from-document).
 
 ## Working with Word document properties
 

--- a/File-Formats/DocIO/Working-with-Word-document.md
+++ b/File-Formats/DocIO/Working-with-Word-document.md
@@ -1017,6 +1017,8 @@ private static void IterateParagraph(ParagraphItemCollection paraItems)
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Iterate-document-elements).
+
 ## Cloning a Word document
 
 You can create a deep copy of a Word document by using `Clone` method of `WordDocument` class. You can read the template document from file system or stream and create multiple document copies by cloning it. This improves the performance of document generation, as there is no need to read the Word document each time.
@@ -1103,7 +1105,9 @@ using (WordDocument document = new WordDocument(assembly.GetManifestResourceStre
 {% endhighlight %}
 
 {% endtabs %}  
- 
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Clone-whole-Word-document).
+
 You can also create a deep copy of document elements such as sections, paragraphs, Tables, Text, Image, OleObject, Shapes, TextBoxes and etc., The following code example illustrates how to clone the section and save each cloned section as a Word document. 
 
 {% tabs %} 
@@ -1215,7 +1219,9 @@ sourceDocument.Close();
 {% endhighlight %}
 
 {% endtabs %}  
-   
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Split-by-section).
+
 ## Merging Word documents
 
 You can merge multiple Word documents into single Word document by using DocIO’s capability of importing contents from one document to another. The imported contents are appended at the end of document.  The following code example illustrates how to import the contents from source document into destination document where the contents are appended. 
@@ -1314,6 +1320,8 @@ using (WordDocument document = new WordDocument(assembly.GetManifestResourceStre
 {% endhighlight %}
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Merge-documents-in-new-page).
 
 In the resultant document, the imported contents start from a new page followed by existing contents in a destination document. This is the default behavior.
 
@@ -1423,6 +1431,8 @@ using (WordDocument document = new WordDocument(assembly.GetManifestResourceStre
 {% endhighlight %}
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Merge-documents-in-same-page).
 
 ### Maintain Imported List style information
 
@@ -1782,7 +1792,7 @@ End Sub
 {% endhighlight %}
 {% endtabs %}   
 
-You can download the complete working samples of the code from [here](https://www.syncfusion.com/downloads/support/directtrac/general/Sample-627835418.zip#).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Print-Word-document).
 
 ## Working with Styles
 
@@ -1905,6 +1915,8 @@ using (WordDocument document = new WordDocument(assembly.GetManifestResourceStre
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Access-styles-in-document).
+
 ### Creating a new Paragraph Style
 
 You can create a new paragraph style by using `WordDocument.AddParagraphStyle` method and apply it by using `ApplyStyle` method of `WParagraph` class.
@@ -2025,6 +2037,8 @@ using (WordDocument document = new WordDocument(assembly.GetManifestResourceStre
  
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Create-new-paragraph-style).
+
 ### Applying built-in styles
 
 DocIO provides a set of predefined styles. You can apply those predefined styles as shown in the following code example.
@@ -2113,6 +2127,8 @@ using (WordDocument document = new WordDocument(assembly.GetManifestResourceStre
 {% endhighlight %}
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Apply-built-in-style).
 
 ### Remove Styles
 
@@ -2215,6 +2231,8 @@ Please download the helper files from the following link to save the stream as a
 {% endhighlight %}
 
 {% endtabs %} 
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Remove-particular-style-from-documents).
 
 ## Working with Word document properties
 
@@ -2323,6 +2341,8 @@ using (WordDocument document = new WordDocument(assembly.GetManifestResourceStre
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Modify-built-in-document-properties).
+
 ### Updating words count
 
 You can update the count of Paragraphs, words and characters in an existing Word document or document that created from the scratch.
@@ -2410,6 +2430,8 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Update-words-count).
+
 ### Updating pages count
 
 You can update page count in an existing Word document or document that created from the scratch by passing true for `UpdateWordCount(performLayout)` API.
@@ -2480,6 +2502,8 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 }
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Update-pages-count).
 
 N>  1. The word to PDF layout engine is used for updating the page count in word document. Due to its limitations it may result in an incorrect page count.
 N>  2. In ASP.NET Core and Xamarin platforms, to update page count in a Word document we recommend you to use Word to PDF [assemblies](https://help.syncfusion.com/file-formats/docio/assemblies-required#converting-word-document-to-pdf) or [NuGet](https://help.syncfusion.com/file-formats/docio/nuget-packages-required#converting-word-document-to-pdf) as a reference in your application to update page count in a Word document.
@@ -2582,6 +2606,8 @@ using (WordDocument document = new WordDocument(assembly.GetManifestResourceStre
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Add-custom-document-properties).
+
 ### Accessing & Modifying Custom Document Properties
 
 You can access and modify an existing document property as shown in the following code example.
@@ -2668,6 +2694,8 @@ using (WordDocument document = new WordDocument(assembly.GetManifestResourceStre
 {% endhighlight %}
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Modify-custom-document-properties).
 
 ## Working with Content Type Properties
 
@@ -3006,6 +3034,8 @@ document.Close();
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Modify-content-type-properties).
   
 ## Setting the Background for a Word document
 
@@ -3132,6 +3162,8 @@ using (WordDocument document = new WordDocument(assembly.GetManifestResourceStre
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Apply-gradient-background-to-document).
+
 The following code illustrates how to apply image as background for the document.
 
 {% tabs %} 
@@ -3240,6 +3272,8 @@ using (WordDocument document = new WordDocument(assembly.GetManifestResourceStre
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Apply-picture-background-to-document).
+
 ## Working with Alternate chunks
 
 Updating Alternate chunk in the Word document, imports the content from the embedded alternate chunk into the main document. When saving the Word document containing alternate chunk as DOCX format document, the alternate chunk content preserved by default. But, when saving as DOC format or other formats, the alternate chunk content will not be preserved. You can use [UpdateAlternateChunks](https://help.syncfusion.com/cr/file-formats/Syncfusion.DocIO.DLS.WordDocument.html#Syncfusion_DocIO_DLS_WordDocument_UpdateAlternateChunks) method to preserve the alternate chunk content by importing into the main document.
@@ -3314,6 +3348,8 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Update-alternate-chunks).
+
 ## Split Word documents
 
 Syncfusion Word Library allows you to split the large Word document into number of smaller word documents by the sections, headings, bookmarks, and placeholder text in programmatically. 
@@ -3322,7 +3358,7 @@ By using this feature, you can be able to split/extract the necessary parts from
 
 You can save the resultant document as a Word document (DOCX, WordML, DOC), PDF, image, HTML, RTF, and more.
 
-### Split by Section.
+### Split by Section
 
 The following code example illustrates how to split the Word document by sections.
 
@@ -3455,7 +3491,9 @@ using (WordDocument document = new WordDocument(fileStream, FormatType.Docx))
 {% endhighlight %}
 {% endtabs %}
 
-### Split by Headings.
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Split-by-section).
+
+### Split by Headings
 
 The following code example illustrates how to split the Word document by using headings.
 
@@ -3903,6 +3941,8 @@ private void SaveWordDocument(WordDocument newDocument, string fileName)
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Split-by-heading).
+
 ### Split by Bookmark
 
 The following code example illustrates how to split the Word document using bookmarks.
@@ -4057,6 +4097,8 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 }
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Split-by-bookmark).
 
 ### Split by placeholder text
 
@@ -4228,3 +4270,5 @@ using (WordDocument document = new WordDocument(inputStream, FormatType.Docx))
 }
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Split-by-placeholder-text).

--- a/File-Formats/DocIO/html.md
+++ b/File-Formats/DocIO/html.md
@@ -423,7 +423,7 @@ N> Calling the above event is mandatory in ASP.NET Core, UWP, and Xamarin platfo
 
 **Frequently Asked Questions**
 
-* [How to get image from URL while opening HTML in .NET Core targeting applications?](https://www.syncfusion.com/kb/12373/how-to-get-image-from-url-while-opening-html-in-asp-net-core)
+* [How to get image from URL while opening HTML in .NET Core targeting applications?](https://www.syncfusion.com/kb/13053/how-to-get-image-from-url-while-opening-html-in-asp-net-core)
 
 ### Customizing the Word to HTML conversion
 

--- a/File-Formats/DocIO/html.md
+++ b/File-Formats/DocIO/html.md
@@ -119,6 +119,8 @@ using (WordDocument document = new WordDocument())
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/HTML-conversion/Convert-HTML-to-Word).
+
 The following code example shows how to convert the Word document into HTML.
 
 {% tabs %}
@@ -199,6 +201,8 @@ using (WordDocument document = new WordDocument())
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/HTML-conversion/Convert-Word-to-HTML).
+
 ## Customization settings
 
 The Essential DocIO provides settings while performing HTML to Word conversion and vice versa.
@@ -253,6 +257,8 @@ document.Save("Sample.docx")
 document.Close()
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/HTML-conversion/Customize-HTML-to-Word-conversion).
 
 N> 1. Inserting XHTML string is not supported in Silverlight, Windows Phone, and Xamarin applications.
 N> 2. XHTML validation against XHTML 1.0 Strict and Transitional schema is not supported in Windows Store applications.
@@ -411,6 +417,8 @@ private void OpenImage(object sender, ImageNodeVisitedEventArgs args)
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/HTML-conversion/Customize-image-data).
+
 N> Calling the above event is mandatory in ASP.NET Core, UWP, and Xamarin platforms to preserve the images in HTML conversions.
 
 **Frequently Asked Questions**
@@ -474,6 +482,8 @@ export.SaveAsXhtml(document, "WordtoHtml.html")
 document.Close()
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/HTML-conversion/Customize-Word-to-HTML-conversion).
 
 ## Supported and unsupported items
 

--- a/File-Formats/DocIO/mail-merge/mail-merge-events.md
+++ b/File-Formats/DocIO/mail-merge/mail-merge-events.md
@@ -222,6 +222,8 @@ private static DataTable GetDataTable()
 
 {% endtabs %} 
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Event-for-mail-merge-field).
+
 ## MergeImageField Event
 
 You can format the merged image like resizing the image and more during mail merge process using the `MergeImageField` Event. 
@@ -427,6 +429,8 @@ private void MergeField_ProductImage(object sender, MergeImageFieldEventArgs arg
 {% endhighlight %}
 
 {% endtabs %} 
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Event-for-image-mail-merge-field).
 
 ## BeforeClearField Event
 
@@ -736,6 +740,8 @@ private DataTable GetDataTable()
 }
 {% endhighlight %} 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Event-to-bind-data-for-unmerged-fields).
 
 ## BeforeClearGroupField Event
 
@@ -1372,3 +1378,5 @@ public class OrderDetails
 }
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Event-to-bind-data-for-unmerged-group).

--- a/File-Formats/DocIO/mail-merge/mail-merge-for-group.md
+++ b/File-Formats/DocIO/mail-merge/mail-merge-for-group.md
@@ -122,6 +122,8 @@ End Function
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Mail-merge-for-group).
+
 The resultant document looks as follows.
 
 ![Group resultant document](../MailMerge_images/Group_mail_merge_output.png)
@@ -517,3 +519,5 @@ public class Employee
 }
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Mail-merge-with-.NET-objects).

--- a/File-Formats/DocIO/mail-merge/mail-merge-for-nested-groups.md
+++ b/File-Formats/DocIO/mail-merge/mail-merge-for-nested-groups.md
@@ -123,6 +123,8 @@ End Function
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Mail-merge-for-nested-group).
+
 The resultant document looks as follows.
 
 ![Nested group mail merged document](../MailMerge_images/Nested_group_mail_merge_output.png)
@@ -423,6 +425,8 @@ private dynamic GetDynamicOrder(int orderID, string orderName, int customerID)
 //You can use IDictionary<string, object> collection to generate dynamic objects.
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Mail-merge-with-dynamic-objects).
 
 ## Mail merge with implicit relational data
 
@@ -880,6 +884,8 @@ public class EmployeeDetails
 }
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Mail-merge-with-implicit-relational-data).
 
 By executing the above code example, it generates the resultant Word document as follows.
  

--- a/File-Formats/DocIO/mail-merge/mail-merge-for-nested-groups.md
+++ b/File-Formats/DocIO/mail-merge/mail-merge-for-nested-groups.md
@@ -131,9 +131,9 @@ The resultant document looks as follows.
 
 ## Mail merge with dynamic objects
 
-Essential DocIO allows you to perform Mail merge with the dynamic objects. The [ExpandoObject](https://msdn.microsoft.com/en-us/library/system.dynamic.expandoobject(v=vs.110).aspx) is like a collection of key and value pairs, which means IDictionary<string, object>. So, you can also use IDictionary<string, object> collection instead of [ExpandoObject](https://msdn.microsoft.com/en-us/library/system.dynamic.expandoobject(v=vs.110).aspx) to execute mail merge.
+Essential DocIO allows you to perform Mail merge with the dynamic objects. The [ExpandoObject](https://docs.microsoft.com/en-us/dotnet/api/system.dynamic.expandoobject?view=net-6.0) is like a collection of key and value pairs, which means IDictionary<string, object>. So, you can also use IDictionary<string, object> collection instead of [ExpandoObject](https://docs.microsoft.com/en-us/dotnet/api/system.dynamic.expandoobject?view=net-6.0) to execute mail merge.
 
-The following code snippet shows how to perform the Mail merge with dynamic objects ([ExpandoObject](https://msdn.microsoft.com/en-us/library/system.dynamic.expandoobject(v=vs.110).aspx)).
+The following code snippet shows how to perform the Mail merge with dynamic objects ([ExpandoObject](https://docs.microsoft.com/en-us/dotnet/api/system.dynamic.expandoobject?view=net-6.0)).
 
 {% tabs %}  
 

--- a/File-Formats/DocIO/mail-merge/mail-merge-options.md
+++ b/File-Formats/DocIO/mail-merge/mail-merge-options.md
@@ -6,7 +6,7 @@ control: DocIO
 documentation: UG
 ---
 
-# Mail merge options
+# Mail merge options in Word Library
 
 The `MailMerge` class allows you to customize the Mail merge process with the following options.
 

--- a/File-Formats/DocIO/mail-merge/mail-merge-options.md
+++ b/File-Formats/DocIO/mail-merge/mail-merge-options.md
@@ -138,6 +138,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 
 {% endtabs %} 
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Mapping-field-names-with-column-names).
+
 ## Retrieve the merge field names
 
 You can retrieve the merge field names and also merge field group names in the Word document.
@@ -234,6 +236,8 @@ string[] fieldNames = document.MailMerge.GetMergeFieldNames(groupName);
 {% endhighlight %}
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Retrieve-merge-field-names).
 
 ## Remove empty paragraphs
 
@@ -337,6 +341,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Remove-empty-paragraphs).
 
 N>If any white space or line break exists in the merge field's parent paragraph, then it will not be considered as empty paragraph and not removed during mail merge process.
 
@@ -454,6 +460,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 //https://help.syncfusion.com/file-formats/docio/create-word-document-in-xamarin#helper-files-for-xamarin
 {% endhighlight %}
 {% endtabs %} 
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Keep-unmerged-merge-fields).
 
 ## Remove empty group
 
@@ -1061,6 +1069,8 @@ public class OrderDetails
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Remove-empty-merge-field-groups).
+
 ## Restart numbering in lists
 
 You can restart the list numbering for each records while performing mail merge for a group in Word document.
@@ -1308,6 +1318,8 @@ public class Employee
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Restart-list-numbering-in-mail-merge).
+
 ## Insert as new row
 
 You can add each record as new row inside table when the row group contains only one cell, which means, the merge fields denoting **group start and end present inside the same cell.**
@@ -1459,6 +1471,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Insert-as-new-row).
 
 ## Skip to merge image
 
@@ -1653,6 +1667,8 @@ private void MergeEmployeePhoto(object sender, MergeImageFieldEventArgs args)
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Skip-to-merge-image).
+
 ## Remove mail merge settings
 
 To **restore a Word mail merge main document to a normal Word document** using Microsoft Word application, you have to process the steps suggested in this [article](https://support.microsoft.com/en-in/help/275995/how-to-restore-a-mail-merge-main-document-to-a-normal-word-document-in) manually. You can achieve this programmatically in just 2 lines of code using Syncfusion Word library.
@@ -1744,6 +1760,8 @@ Xamarin.Forms.DependencyService.Get&lt;ISave&gt;().SaveAndView("Sample.docx", "a
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Remove-mail-merge-settings).
+
 ## Change mail merge data source path 
 
 You can change the linked **data source file path from a Word mail merge main document**, which is used for mail merge process by Microsoft Word application.
@@ -1825,3 +1843,5 @@ Xamarin.Forms.DependencyService.Get&lt;ISave&gt;().SaveAndView("Sample.docx", "a
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Change-mail-merge-data-source-path).

--- a/File-Formats/DocIO/mail-merge/simple-mail-merge.md
+++ b/File-Formats/DocIO/mail-merge/simple-mail-merge.md
@@ -150,6 +150,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Template.docx", "appli
 
 {% endtabs %}  
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Create-Word-document-template).
+
 The generated template document looks as follows.
 
 ![Word document template](../MailMerge_images/Simple_mail_merge_template.png)
@@ -244,6 +246,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "applica
 {% endhighlight %}
 
 {% endtabs %}  
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Mail-merge-with-string-arrays).
 
 The resultant document looks as follows.
 

--- a/File-Formats/DocIO/mail-merge/simple-mail-merge.md
+++ b/File-Formats/DocIO/mail-merge/simple-mail-merge.md
@@ -6,7 +6,7 @@ control: DocIO
 documentation: UG
 ---
 
-# Simple Mail merge
+# Simple Mail merge in Word document
 
 You can create a Word document template using Microsoft Word application or by adding merge fields in the Word document programmatically. For further information, click [here](https://help.syncfusion.com/file-formats/docio/working-with-mail-merge#create-word-document-template).
 

--- a/File-Formats/DocIO/rtf.md
+++ b/File-Formats/DocIO/rtf.md
@@ -86,6 +86,8 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/RTF-conversion/Convert-RTF-to-Word).
+
 The following code example shows how to convert Word document into RTF document.
 
 {% tabs %}
@@ -190,6 +192,8 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 }
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/RTF-conversion/Convert-Word-to-RTF).
 
 ## Supported and Unsupported features
 The supported and unsupported features of DocIO based on file formats can be referred [here](https://help.syncfusion.com/file-formats/docio/supported-and-unsupported-features#)

--- a/File-Formats/DocIO/rtf.md
+++ b/File-Formats/DocIO/rtf.md
@@ -6,7 +6,7 @@ control: DocIO
 documentation: UG
 ---
 
-# RTF Conversion
+# RTF Conversions in Word Library
 
 ## RTF
 The [Rich Text Format (RTF)](http://en.wikipedia.org/wiki/Rich_Text_Format#) is one of the document formats supported by Microsoft Word and many other Word processing applications. RTF is human readable file format invented for interchanging formatted text between applications. It is an optional format for Word that retains most formatting and all content of the original document.

--- a/File-Formats/DocIO/text.md
+++ b/File-Formats/DocIO/text.md
@@ -114,6 +114,8 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Text-file-conversion/Convert-Word-to-text-file).
+
 The following code example shows how to convert a Text file into Word document.
 
 {% tabs %}
@@ -186,6 +188,8 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Text-file-conversion/Convert-text-file-to-Word).
 
 The following code example shows how to retrieve the Word document contents as a plain text.
 
@@ -311,3 +315,5 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 }
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Text-file-conversion/Retrieve-Word-document-as-plain-text).

--- a/File-Formats/DocIO/text.md
+++ b/File-Formats/DocIO/text.md
@@ -6,7 +6,7 @@ control: DocIO
 documentation: UG
 ---
 
-# Text Conversion
+# Text Conversions in Word Library
 
 The Essential DocIO converts the Word document into Text file and vice versa. The following code example shows how to convert the Word document into text file.
 

--- a/File-Formats/DocIO/word-file-formats.md
+++ b/File-Formats/DocIO/word-file-formats.md
@@ -118,6 +118,8 @@ using (WordDocument document = new WordDocument())
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-file-formats/Create-Docx-format-Word-document).
+
 ### Templates
 
 DOTX is a Word document template. The following code snippet shows how to create the Word document template with few lines of code.
@@ -206,6 +208,8 @@ using (WordDocument document = new WordDocument())
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-file-formats/Create-Dotx-format-Word-document).
+
 ### Macros
 
 DOCM is a macro enabled Word document. It is same as DOCX document contains macros and scripts. The DocIO provides only preservation support for macros. The following code illustrates how to load and save a macro enabled document using the DocIO library.
@@ -263,6 +267,8 @@ using (WordDocument document = new WordDocument(fileStreamPath, FormatType.Dotm)
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Macros/Open-and-save-macro-enabled-document).
 
 ## Word Processing XML (.xml)
 
@@ -347,6 +353,8 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-file-formats/Convert-Word-to-WordML).
+
 The following code example shows how to convert the Word Processing XML document into Word document.
 
 {% tabs %}
@@ -419,6 +427,8 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-file-formats/Convert-WordML-to-Word).
 
 ### Unsupported elements in Word to Word Processing XML conversion:
 
@@ -600,6 +610,8 @@ using (WordDocument document = new WordDocument())
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-file-formats/Create-Doc-format-Word-document).
+
 ### DOC to DOCX and DOCX to DOC
 The following code shows, how to convert the DOC file into DOCX file format using DocIO
 
@@ -674,6 +686,9 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-file-formats/Convert-Doc-to-Docx).
+
 The following code shows, how to convert the DOCX file into DOC file format using DocIO
 
 {% tabs %}
@@ -781,6 +796,8 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-file-formats/Convert-Docx-to-Doc).
+
 ### Saving Word document with compatibility
 
 The following code shows, how to save Word document with same word version compatibility
@@ -882,6 +899,8 @@ using (WordDocument document = new WordDocument())
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-file-formats/Save-Word-with-compatibility).
 
 ### Open a Word (*.doc) document containing incremental save information
 
@@ -1126,3 +1145,5 @@ using (WordDocument document = new WordDocument())
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-file-formats/Ole-image-as-normal-image).

--- a/File-Formats/DocIO/word-to-epub.md
+++ b/File-Formats/DocIO/word-to-epub.md
@@ -100,6 +100,8 @@ async void Save(MemoryStream streams, string filename)
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-to-EPUB-conversion/Convert-Word-to-EPUB).
+
 N> 1. Word to EPUB conversion is supported only in Windows Forms, UWP, WPF, ASP.NET Web, and MVC platforms.
 
 The following elements are supported in Word to EPUB conversion.

--- a/File-Formats/DocIO/word-to-image.md
+++ b/File-Formats/DocIO/word-to-image.md
@@ -127,6 +127,7 @@ wordDocument.Close()
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-to-Image-conversion/Convert-Word-to-image).
 
 The following code snippet illustrates how to convert a Word document to an image using custom image resolution.
 
@@ -205,6 +206,8 @@ End Using
 //DocIO only supports Word to image conversion in Windows Forms, WPF, ASP.NET and ASP.NET MVC platform.
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-to-Image-conversion/Custom-image-resolution).
 
 N> 1. Word to Image conversion is not supported in Silverlight, Windows Phone, WinRT, Universal, Xamarin, ASP.NET Core, Blazor and Universal Windows Platform applications.
 N> 2. In Azure Web Service and Azure APP Service, .NET GDI+ (System.Drawing) does not support the Metafile image (vector image). So, the image will be generated as Bitmap (raster image).

--- a/File-Formats/DocIO/word-to-odt.md
+++ b/File-Formats/DocIO/word-to-odt.md
@@ -114,6 +114,8 @@ using (WordDocument document = new WordDocument((assembly.GetManifestResourceStr
 
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-to-ODT-conversion/Convert-Word-to-ODT).
+
 ## Supported Document elements
 <table>
 <thead> 

--- a/File-Formats/DocIO/working-with-mail-merge.md
+++ b/File-Formats/DocIO/working-with-mail-merge.md
@@ -127,6 +127,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Template.docx", "appli
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Create-merge-field).
+
 ### Execute mail merge
 
 The following code example shows how to perform mail merge in above Word document template using string arrays as data source.
@@ -214,6 +216,8 @@ document.Close();
 //https://help.syncfusion.com/file-formats/docio/create-word-document-in-xamarin#helper-files-for-xamarin
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Getting-started-mail-merge).
 
 By executing the previous code example, it generates the resultant Word document as follows.
 


### PR DESCRIPTION
Kindly review the below merge request and let me know your feedback.

<table>
<tr>
<td>
Task Link
</td>
<td>
<a href="https://syncfusion.atlassian.net/browse/WF-62692">https://syncfusion.atlassian.net/browse/WF-62692</a>
</td>
</tr>
<tr>
<td>
Description
</td>
<td>
Add GitHub sample link in UG documentation.
</td>
</tr>
<tr>
<td>
Changes done
</td>
<td>
Added GitHub sample link in UG documentation in below pages, 
<p></p>

- Fields
- Mail-Merge
- Word-document
- RTF-conversion
- Text-file-conversion
- HTML-conversion
- Word-file-formats
- Word-to-EPUB-conversion
- Word-to-Image-conversion
- Word-to-ODT-conversion

</td>
</tr>
</table>