### PR TITLE
WF-62949-Added redirection links to the existing Url in Word document page

### DIFF
--- a/File-Formats/DocIO/Working-with-Paragraph.md
+++ b/File-Formats/DocIO/Working-with-Paragraph.md
@@ -798,6 +798,128 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Result.docx", "applica
 
 You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Add-tab-stop).
 
+### RTL paragraph
+
+You can set RTL (Right-to-left) direction to the paragraph in a Word document. The following code example shows how to set RTL (Right-to-left) for a paragraph in Word document.
+
+{% tabs %}  
+
+{% highlight c# tabtitle="C#" %}
+//Loads the template document
+WordDocument document = new WordDocument("Template.docx");
+//Gets the text body of first section
+WTextBody textBody = document.Sections[0].Body;
+//Gets the paragraph at index 1
+WParagraph paragraph = textBody.Paragraphs[1];
+//Gets a value indicating whether the paragraph is right-to-left. True indicates the paragraph direction is RTL
+bool isRTL = paragraph.ParagraphFormat.Bidi;
+//Sets RTL direction for a paragraph
+if(!isRTL)
+    paragraph.ParagraphFormat.Bidi = true;
+//Saves the Word document
+document.Save("Sample.docx", FormatType.Docx);
+//Closes the document
+document.Close();
+{% endhighlight %}
+
+{% highlight vb.net tabtitle="VB.NET" %}
+'Loads the template document
+Dim document As WordDocument = New WordDocument("Template.docx")
+'Gets the text body of first section
+Dim textBody As WTextBody = document.Sections(0).Body
+'Gets the paragraph at index 1
+Dim paragraph As WParagraph = textBody.Paragraphs(1)
+'Gets a value indicating whether the paragraph is right-to-left. True indicates the paragraph direction is RTL
+Dim isRTL As Boolean = paragraph.ParagraphFormat.Bidi
+'Sets RTL direction for a paragraph
+If Not isRTL Then
+    paragraph.ParagraphFormat.Bidi = True
+End If
+'Saves the Word document
+document.Save("Sample.docx", FormatType.Docx)
+'Closes the document
+document.Close()
+{% endhighlight %}
+
+{% highlight c# tabtitle="UWP" %}
+//"App" is the class of Portable project
+Assembly assembly = typeof(App).GetTypeInfo().Assembly;
+//Loads the template document
+WordDocument document = new WordDocument(assembly.GetManifestResourceStream("Sample.Assets.Template.docx"), FormatType.Docx);
+//Gets the text body of first section
+WTextBody textBody = document.Sections[0].Body;
+//Gets the paragraph at index 1
+WParagraph paragraph = textBody.Paragraphs[1];
+//Gets a value indicating whether the paragraph is right-to-left. True indicates the paragraph direction is RTL
+bool isRTL = paragraph.ParagraphFormat.Bidi;
+//Sets RTL direction for a paragraph
+if(!isRTL)
+    paragraph.ParagraphFormat.Bidi = true;
+//Saves and closes the Word document instance
+MemoryStream stream = new MemoryStream();
+//Saves the Word file to MemoryStream
+document.Save(stream, FormatType.Docx);
+document.Close();
+//Saves the stream as Word file in local machine
+Save(stream, "Sample.docx");
+
+//Refer to the following link to save Word document in UWP platform
+//https://help.syncfusion.com/file-formats/docio/create-word-document-in-uwp#save-word-document-in-uwp
+{% endhighlight %} 
+
+{% highlight c# tabtitle="ASP.NET Core" %}
+FileStream fileStreamPath = new FileStream("Template.docx", FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+//Loads or opens an existing Word document through Open method of WordDocument class
+WordDocument document = new WordDocument(fileStreamPath, FormatType.Docx);
+//Gets the text body of first section
+WTextBody textBody = document.Sections[0].Body;
+//Gets the paragraph at index 1
+WParagraph paragraph = textBody.Paragraphs[1];
+//Gets a value indicating whether the paragraph is right-to-left. True indicates the paragraph direction is RTL
+bool isRTL = paragraph.ParagraphFormat.Bidi;
+//Sets RTL direction for a paragraph
+if(!isRTL)
+    paragraph.ParagraphFormat.Bidi = true;
+//Saves and closes the Word document instance
+MemoryStream stream = new MemoryStream();
+//Saves the Word document to MemoryStream
+document.Save(stream, FormatType.Docx);
+document.Close();
+stream.Position = 0;
+//Download Word document in the browser
+return File(stream, "application/msword", "Sample.docx");
+{% endhighlight %} 
+
+{% highlight c# tabtitle="Xamarin" %}
+//"App" is the class of Portable project
+Assembly assembly = typeof(App).GetTypeInfo().Assembly;
+//Loads or opens an existing Word document through Open method of WordDocument class
+WordDocument document = new WordDocument(assembly.GetManifestResourceStream("Sample.Assets.Template.docx"), FormatType.Docx);
+//Gets the text body of first section
+WTextBody textBody = document.Sections[0].Body;
+//Gets the paragraph at index 1
+WParagraph paragraph = textBody.Paragraphs[1];
+//Gets a value indicating whether the paragraph is right-to-left. True indicates the paragraph direction is RTL
+bool isRTL = paragraph.ParagraphFormat.Bidi;
+//Sets RTL direction for a paragraph
+if(!isRTL)
+    paragraph.ParagraphFormat.Bidi = true;
+//Saves and closes the Word document instance
+MemoryStream stream = new MemoryStream();
+//Saves the Word file to MemoryStream
+document.Save(stream, FormatType.Docx);
+document.Close();
+//Save the stream as a file in the device and invoke it for viewing
+Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "application/msword", stream);
+
+//Download the helper files from the following link to save the stream as file and open the file for viewing in Xamarin platform
+//https://help.syncfusion.com/file-formats/docio/create-word-document-in-xamarin#helper-files-for-xamarin
+{% endhighlight %}
+
+{% endtabs %}   
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/RTL-paragraph).
+
 ## Working with Styles
 
 A style is a predefined set of table, numbering, paragraph, and character properties that can be applied to regions within a document. DocIO provides the following functionalities related with styles.
@@ -1237,128 +1359,6 @@ Please download the helper files from the following link to save the stream as a
 {% endtabs %} 
 
 You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-document/Remove-particular-style-from-document).
-
-### RTL paragraph
-
-You can set RTL (Right-to-left) direction to the paragraph in a Word document. The following code example shows how to set RTL (Right-to-left) for a paragraph in Word document.
-
-{% tabs %}  
-
-{% highlight c# tabtitle="C#" %}
-//Loads the template document
-WordDocument document = new WordDocument("Template.docx");
-//Gets the text body of first section
-WTextBody textBody = document.Sections[0].Body;
-//Gets the paragraph at index 1
-WParagraph paragraph = textBody.Paragraphs[1];
-//Gets a value indicating whether the paragraph is right-to-left. True indicates the paragraph direction is RTL
-bool isRTL = paragraph.ParagraphFormat.Bidi;
-//Sets RTL direction for a paragraph
-if(!isRTL)
-    paragraph.ParagraphFormat.Bidi = true;
-//Saves the Word document
-document.Save("Sample.docx", FormatType.Docx);
-//Closes the document
-document.Close();
-{% endhighlight %}
-
-{% highlight vb.net tabtitle="VB.NET" %}
-'Loads the template document
-Dim document As WordDocument = New WordDocument("Template.docx")
-'Gets the text body of first section
-Dim textBody As WTextBody = document.Sections(0).Body
-'Gets the paragraph at index 1
-Dim paragraph As WParagraph = textBody.Paragraphs(1)
-'Gets a value indicating whether the paragraph is right-to-left. True indicates the paragraph direction is RTL
-Dim isRTL As Boolean = paragraph.ParagraphFormat.Bidi
-'Sets RTL direction for a paragraph
-If Not isRTL Then
-    paragraph.ParagraphFormat.Bidi = True
-End If
-'Saves the Word document
-document.Save("Sample.docx", FormatType.Docx)
-'Closes the document
-document.Close()
-{% endhighlight %}
-
-{% highlight c# tabtitle="UWP" %}
-//"App" is the class of Portable project
-Assembly assembly = typeof(App).GetTypeInfo().Assembly;
-//Loads the template document
-WordDocument document = new WordDocument(assembly.GetManifestResourceStream("Sample.Assets.Template.docx"), FormatType.Docx);
-//Gets the text body of first section
-WTextBody textBody = document.Sections[0].Body;
-//Gets the paragraph at index 1
-WParagraph paragraph = textBody.Paragraphs[1];
-//Gets a value indicating whether the paragraph is right-to-left. True indicates the paragraph direction is RTL
-bool isRTL = paragraph.ParagraphFormat.Bidi;
-//Sets RTL direction for a paragraph
-if(!isRTL)
-    paragraph.ParagraphFormat.Bidi = true;
-//Saves and closes the Word document instance
-MemoryStream stream = new MemoryStream();
-//Saves the Word file to MemoryStream
-document.Save(stream, FormatType.Docx);
-document.Close();
-//Saves the stream as Word file in local machine
-Save(stream, "Sample.docx");
-
-//Refer to the following link to save Word document in UWP platform
-//https://help.syncfusion.com/file-formats/docio/create-word-document-in-uwp#save-word-document-in-uwp
-{% endhighlight %} 
-
-{% highlight c# tabtitle="ASP.NET Core" %}
-FileStream fileStreamPath = new FileStream("Template.docx", FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-//Loads or opens an existing Word document through Open method of WordDocument class
-WordDocument document = new WordDocument(fileStreamPath, FormatType.Docx);
-//Gets the text body of first section
-WTextBody textBody = document.Sections[0].Body;
-//Gets the paragraph at index 1
-WParagraph paragraph = textBody.Paragraphs[1];
-//Gets a value indicating whether the paragraph is right-to-left. True indicates the paragraph direction is RTL
-bool isRTL = paragraph.ParagraphFormat.Bidi;
-//Sets RTL direction for a paragraph
-if(!isRTL)
-    paragraph.ParagraphFormat.Bidi = true;
-//Saves and closes the Word document instance
-MemoryStream stream = new MemoryStream();
-//Saves the Word document to MemoryStream
-document.Save(stream, FormatType.Docx);
-document.Close();
-stream.Position = 0;
-//Download Word document in the browser
-return File(stream, "application/msword", "Sample.docx");
-{% endhighlight %} 
-
-{% highlight c# tabtitle="Xamarin" %}
-//"App" is the class of Portable project
-Assembly assembly = typeof(App).GetTypeInfo().Assembly;
-//Loads or opens an existing Word document through Open method of WordDocument class
-WordDocument document = new WordDocument(assembly.GetManifestResourceStream("Sample.Assets.Template.docx"), FormatType.Docx);
-//Gets the text body of first section
-WTextBody textBody = document.Sections[0].Body;
-//Gets the paragraph at index 1
-WParagraph paragraph = textBody.Paragraphs[1];
-//Gets a value indicating whether the paragraph is right-to-left. True indicates the paragraph direction is RTL
-bool isRTL = paragraph.ParagraphFormat.Bidi;
-//Sets RTL direction for a paragraph
-if(!isRTL)
-    paragraph.ParagraphFormat.Bidi = true;
-//Saves and closes the Word document instance
-MemoryStream stream = new MemoryStream();
-//Saves the Word file to MemoryStream
-document.Save(stream, FormatType.Docx);
-document.Close();
-//Save the stream as a file in the device and invoke it for viewing
-Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("Sample.docx", "application/msword", stream);
-
-//Download the helper files from the following link to save the stream as file and open the file for viewing in Xamarin platform
-//https://help.syncfusion.com/file-formats/docio/create-word-document-in-xamarin#helper-files-for-xamarin
-{% endhighlight %}
-
-{% endtabs %}   
-
-You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/RTL-paragraph).
 
 ## Working with Text 
 

--- a/File-Formats/DocIO/Working-with-Word-document.md
+++ b/File-Formats/DocIO/Working-with-Word-document.md
@@ -15,6 +15,8 @@ The following are the important points to be remembered while iterating the docu
 * Section contains the contents present in Headers, Footers and main document through the instances of `WTextBody`.
 * `WTextBody` contains three type of elements – either paragraph, table or block content control.
 
+For further information, click [here](https://help.syncfusion.com/file-formats/docio/word-document/iterating-word-document-elements).
+
 ## Cloning a Word document
 
 You can create a deep copy of a Word document by using `Clone` method of `WordDocument` class. You can read the template document from file system or stream and create multiple document copies by cloning it. This improves the performance of document generation, as there is no need to read the Word document each time.
@@ -220,35 +222,35 @@ You can download a complete working sample from [GitHub](https://github.com/Sync
 
 ## Merging Word documents
 
-You can merge multiple Word documents into single Word document by using DocIO’s capability of importing contents from one document to another.
+You can merge multiple Word documents into single Word document by using DocIO’s capability of importing contents from one document to another. For further information, click [here](https://help.syncfusion.com/file-formats/docio/word-document/merging-word-documents). 
 
 ### Maintain Imported List style information
 
-You can maintain information about imported list styles in a Word document while cloning and merging multiple Word documents.
+You can maintain information about imported list styles in a Word document while cloning and merging multiple Word documents. For further information, click [here](https://help.syncfusion.com/file-formats/docio/word-document/merging-word-documents#maintain-imported-list-style-information).
 
 ## Printing a Word document
 
-You can print a Word document by utilizing DocIO’s capability to convert the document into images and .NET framework’s [PrintDocument](https://docs.microsoft.com/en-us/dotnet/api/system.drawing.printing.printdocument?view=net-5.0) class.
+You can print a Word document by utilizing DocIO’s capability to convert the document into images and .NET framework’s [PrintDocument](https://docs.microsoft.com/en-us/dotnet/api/system.drawing.printing.printdocument?view=net-5.0) class. For further information, click [here](https://help.syncfusion.com/file-formats/docio/word-document/print-word-documents).
 
 ## Working with Styles
 
-A style is a predefined set of table, numbering, paragraph, and character properties that can be applied to regions within a document.
+A style is a predefined set of table, numbering, paragraph, and character properties that can be applied to regions within a document. For further information, click [here](https://help.syncfusion.com/file-formats/docio/working-with-paragraph#working-with-styles).
 
 ### Access Styles
 
-Paragraph and character styles present in the existing document are accessible through the `Styles` property of `WordDocument` class.
+Paragraph and character styles present in the existing document are accessible through the `Styles` property of `WordDocument` class. For further information, click [here](https://help.syncfusion.com/file-formats/docio/working-with-paragraph#access-styles).
 
 ### Creating a new Paragraph Style
 
-You can create a new paragraph style by using `WordDocument.AddParagraphStyle` method and apply it by using `ApplyStyle` method of `WParagraph` class.
+You can create a new paragraph style by using `WordDocument.AddParagraphStyle` method and apply it by using `ApplyStyle` method of `WParagraph` class. For further information, click [here](https://help.syncfusion.com/file-formats/docio/working-with-paragraph#creating-a-new-paragraph-style).
 
 ### Applying built-in styles
 
-DocIO provides a set of predefined styles. You can apply those predefined styles.
+DocIO provides a set of predefined styles. You can apply those predefined styles. For further information, click [here](https://help.syncfusion.com/file-formats/docio/working-with-paragraph#applying-built-in-styles).
 
 ### Remove Styles
 
-You can remove the styles present in the existing document using the `Remove` method.
+You can remove the styles present in the existing document using the `Remove` method. For further information, click [here](https://help.syncfusion.com/file-formats/docio/working-with-paragraph#remove-styles).
 
 ## Working with Word document properties
 
@@ -1368,20 +1370,20 @@ You can download a complete working sample from [GitHub](https://github.com/Sync
 
 ## Split Word documents
 
-Syncfusion Word Library allows you to split the large Word document into number of smaller word documents by the sections, headings, bookmarks, and placeholder text in programmatically.
+Syncfusion Word Library allows you to split the large Word document into number of smaller word documents by the sections, headings, bookmarks, and placeholder text in programmatically. For further information, click [here](https://help.syncfusion.com/file-formats/docio/word-document/split-word-documents).
 
 ### Split by Section
 
-You can split the Word document by sections.
+You can split the Word document by sections. For further information, click [here](https://help.syncfusion.com/file-formats/docio/word-document/split-word-documents#split-by-section).
 
 ### Split by Headings
 
-You can split the Word document by using headings.
+You can split the Word document by using headings. For further information, click [here](https://help.syncfusion.com/file-formats/docio/word-document/split-word-documents#split-by-headings).
 
 ### Split by Bookmark
 
-You can split the Word document using bookmarks.
+You can split the Word document using bookmarks. For further information, click [here](https://help.syncfusion.com/file-formats/docio/word-document/split-word-documents#split-by-bookmark).
 
 ### Split by placeholder text
 
-You can split the Word document using the placeholder text.
+You can split the Word document using the placeholder text. For further information, click [here](https://help.syncfusion.com/file-formats/docio/word-document/split-word-documents#split-by-placeholder-text).


### PR DESCRIPTION
Kindly review the below merge request and let me know your feedback.

<table>
<tr>
<td>
Task Link
</td>
<td>
<a href="https://syncfusion.atlassian.net/browse/WF-62949">https://syncfusion.atlassian.net/browse/WF-62949</a>
</td>
</tr>
<tr>
<td>
Description
</td>
<td>
Divide the existing Working With Word Document UG documentation as sub page documents.
</td>
</tr>
<tr>
<td>
Changes done
</td>
<td>
Added redirection links to the existing url in Word document page in order to avoid broken links, 
<p></p>

- Iterating Word document elements
- Merging Word Documents
- Print Word documents
- Split Word documents
- Working with Styles

</td>
</tr>
</table>