### PR TITLE
WF-63104-Add UG documentation to get or set internal margins for shapes in Word document

### DIFF
--- a/File-Formats/DocIO/Working-with-Shapes.md
+++ b/File-Formats/DocIO/Working-with-Shapes.md
@@ -227,6 +227,14 @@ rectangle.VerticalOrigin = VerticalOrigin.Page;
 //Sets line format
 rectangle.LineFormat.DashStyle = LineDashing.Dot;
 rectangle.LineFormat.Color = Color.DarkGray;
+//Sets the left internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Left = 30;
+//Sets the right internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Right = 24;
+//Sets the bottom internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Bottom = 18;
+//Sets the top internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Top = 6;
 //Saves and closes the Word document
 document.Save("Sample.docx", FormatType.Docx);
 document.Close();
@@ -259,6 +267,14 @@ rectangle.VerticalOrigin = VerticalOrigin.Page
 'Sets line format
 rectangle.LineFormat.DashStyle = LineDashing.Dot
 rectangle.LineFormat.Color = Color.DarkGray
+'Sets the left internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Left = 30
+'Sets the right internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Right = 24
+'Sets the bottom internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Bottom = 18
+'Sets the top internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Top = 6
 'Saves and closes the Word document
 document.Save("Sample.docx", FormatType.Docx)
 document.Close()
@@ -291,6 +307,14 @@ rectangle.VerticalOrigin = VerticalOrigin.Page;
 //Sets line format
 rectangle.LineFormat.DashStyle = LineDashing.Dot;
 rectangle.LineFormat.Color = Color.DarkGray;
+//Sets the left internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Left = 30;
+//Sets the right internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Right = 24;
+//Sets the bottom internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Bottom = 18;
+//Sets the top internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Top = 6;
 //Saves and closes the Word document instance
 MemoryStream stream = new MemoryStream();
 //Saves the Word file to MemoryStream
@@ -329,6 +353,14 @@ rectangle.VerticalOrigin = VerticalOrigin.Page;
 //Sets line format
 rectangle.LineFormat.DashStyle = LineDashing.Dot;
 rectangle.LineFormat.Color = Color.DarkGray;
+//Sets the left internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Left = 30;
+//Sets the right internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Right = 24;
+//Sets the bottom internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Bottom = 18;
+//Sets the top internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Top = 6;
 //Saves and closes the Word document instance
 MemoryStream stream = new MemoryStream();
 //Saves the Word document to  MemoryStream
@@ -366,6 +398,14 @@ rectangle.VerticalOrigin = VerticalOrigin.Page;
 //Sets line format
 rectangle.LineFormat.DashStyle = LineDashing.Dot;
 rectangle.LineFormat.Color = Syncfusion.Drawing.Color.DarkGray;
+//Sets the left internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Left = 30;
+//Sets the right internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Right = 24;
+//Sets the bottom internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Bottom = 18;
+//Sets the top internal margin for the shape.
+rectangle.TextFrame.InternalMargin.Top = 6;
 //Saves and closes the Word document instance
 MemoryStream stream = new MemoryStream();
 //Saves the Word file to MemoryStream


### PR DESCRIPTION
Kindly review the below merge request and let me know your feedback.

<table>
<tr>
<td>
Task Link
</td>
<td>
<a href="https://syncfusion.atlassian.net/browse/WF-63104">https://syncfusion.atlassian.net/browse/WF-63104</a>
</td>
</tr>
<tr>
<td>
Description
</td>
<td>
Add UG documentation to get or set internal margins for shapes in Word document.
</td>
</tr>
<tr>
<td>
Solution
</td>
<td>
Added code snippet to set internal margins for shapes in all platforms. <br/>
</td>
</tr>
</table>