### PR TITLE
WF-63101-Link the GitHub samples in UG new features documentation

### DIFF
--- a/File-Formats/DocIO/FAQ.md
+++ b/File-Formats/DocIO/FAQ.md
@@ -4834,7 +4834,7 @@ Before v18.4.0.x
 </td>
 <td>
 Install SkiaSharp.Linux NuGet package for .Net Core application in Linux OS. you can find the SkiaSharp.Linux NuGet package created by us from {{'[here](https://www.syncfusion.com/downloads/support/directtrac/general/ze/SkiaSharp.Linux.1.59.3-2103435070)'| markdownify }}.<br/>
-For more information, Please refer [here](https://help.syncfusion.com/file-formats/docio/faq#how-to-perform-word-to-pdf-in-linux-prior-to-v184-release).
+For more information, Please refer {{'[here](https://help.syncfusion.com/file-formats/docio/faq#how-to-perform-word-to-pdf-in-linux-prior-to-v184-release)'| markdownify }}.
 </td>
 </tr>
 </table>

--- a/File-Formats/DocIO/Working-with-Charts.md
+++ b/File-Formats/DocIO/Working-with-Charts.md
@@ -2583,7 +2583,7 @@ using (WordDocument document = new WordDocument())
     //Saves the Word document to MemoryStream.
     MemoryStream outputStream = new MemoryStream();
     document.Save(outputStream, FormatType.Docx);
-    stream.Position = 0;
+    outputStream.Position = 0;
     //Downloads Word document in the browser.
     return File(outputStream, "application/msword", "Sample.docx");
 }
@@ -2641,6 +2641,8 @@ using (WordDocument document = new WordDocument())
 }
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Charts/Create-waterfall-chart).
 
 By executing the code example above, it generates the resultant Word document as follows.
 

--- a/File-Formats/DocIO/Working-with-Paragraph.md
+++ b/File-Formats/DocIO/Working-with-Paragraph.md
@@ -6052,7 +6052,7 @@ using (FileStream docStream = new FileStream("Template.docx", FileMode.Open, Fil
         //Saves the Word document to MemoryStream.
         MemoryStream outputStream = new MemoryStream();
         document.Save(outputStream, FormatType.Docx);
-        stream.Position = 0;
+        outputStream.Position = 0;
         //Downloads Word document in the browser.
         return File(outputStream, "application/msword", "Sample.docx");
     }
@@ -6083,6 +6083,8 @@ using (Stream docStream = typeof(App).GetTypeInfo().Assembly.GetManifestResource
 }
 {% endhighlight %}
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Paragraphs/Text-wrapping-break).
 
 By executing the code example above, it generates the resultant Word document as follows.
 

--- a/File-Formats/DocIO/mail-merge/mail-merge-events.md
+++ b/File-Formats/DocIO/mail-merge/mail-merge-events.md
@@ -1379,6 +1379,8 @@ public class OrderDetails
 {% endhighlight %}
 {% endtabs %}
 
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Event-to-bind-data-for-unmerged-group).
+
 ## See Also
 
 * [How to add QR code to word using C#, VB.NET](https://www.syncfusion.com/kb/12960/how-to-add-qr-code-to-word-using-c-vb-net-docx)

--- a/File-Formats/DocIO/mail-merge/mail-merge-for-nested-groups.md
+++ b/File-Formats/DocIO/mail-merge/mail-merge-for-nested-groups.md
@@ -123,7 +123,7 @@ End Function
 {% endhighlight %}
 {% endtabs %}
 
-You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Mail-merge-for-group).
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Mail-merge-with-explicit-relational-data).
 
 The resultant document looks as follows.
 

--- a/File-Formats/DocIO/mail-merge/mail-merge-options.md
+++ b/File-Formats/DocIO/mail-merge/mail-merge-options.md
@@ -1761,7 +1761,7 @@ using (FileStream docStream = new FileStream("Template.docx", FileMode.Open, Fil
         //Saves the Word document to MemoryStream.
         MemoryStream outputStream = new MemoryStream();
         document.Save(outputStream, FormatType.Docx);
-        stream.Position = 0;
+        outputStream.Position = 0;
         //Downloads Word document in the browser.
         return File(outputStream, "application/msword", "Sample.docx");
     }
@@ -3480,6 +3480,8 @@ public class OrderTotals
 {% endhighlight %}
 
 {% endtabs %}
+
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Mail-Merge/Start-at-new-page).
 
 By executing the above code example, it generates the resultant Word document as follows.
 


### PR DESCRIPTION
Kindly review the below merge request and let me know your feedback.

<table>
<tr>
<td>
Task Link
</td>
<td>
<a href="https://syncfusion.atlassian.net/browse/WF-63101">https://syncfusion.atlassian.net/browse/WF-63101</a>
</td>
</tr>
<tr>
<td>
Description
</td>
<td>
Add GitHub sample link in UG documentation.
</td>
</tr>
<tr>
<td>
Changes done
</td>
<td>

- Added GitHub sample link in UG documentation for new features.
- Corrected the mistakes in the code snippet in UG documentation.
- Updated the proper GitHub sample link.
- Corrected the hyperlink in FAQ page.

</td>
</tr>
</table>