### PR TITLE
WF-65166-Remove note regarding Word/PPTX to PDF/image not support in Blazor WASM from UG

### DIFF
--- a/File-Formats/DocIO/Supported-and-Unsupported-Features.md
+++ b/File-Formats/DocIO/Supported-and-Unsupported-Features.md
@@ -1238,6 +1238,11 @@ Yes<br/><br/></td></tr>
 <td>Yes<br/><br/></td>
 </tr>
 <tr>
+<td>Word to Image<br/><br/></td>
+<td>Yes<br/><br/></td>
+<td>Yes<br/><br/></td>
+</tr>
+<tr>
 <td>RTF to Word<br/><br/></td>
 <td>Yes<br/><br/></td>
 <td>Yes<br/><br/></td>

--- a/File-Formats/DocIO/Supported-and-Unsupported-Features.md
+++ b/File-Formats/DocIO/Supported-and-Unsupported-Features.md
@@ -1200,7 +1200,7 @@ Yes<br/><br/></td></tr>
 <tr>
 <td>Updating Table of Content<br/><br/></td>
 <td>Yes<br/><br/></td>
-<td>No<br/><br/></td>
+<td>Yes<br/><br/></td>
 </tr>
 <tr>
 <td>Find and Replace<br/><br/></td>
@@ -1235,7 +1235,7 @@ Yes<br/><br/></td></tr>
 <tr>
 <td>Word to PDF<br/><br/></td>
 <td>Yes<br/><br/></td>
-<td>No<br/><br/></td>
+<td>Yes<br/><br/></td>
 </tr>
 <tr>
 <td>RTF to Word<br/><br/></td>

--- a/File-Formats/DocIO/word-to-pdf.md
+++ b/File-Formats/DocIO/word-to-pdf.md
@@ -171,11 +171,10 @@ pdfDocument.Close();
 You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-to-PDF-Conversion/Convert-Word-document-to-PDF).
 
 N> 1. Word to PDF conversion is not supported in Silverlight, Windows Phone, WinRT, and Universal applications.
-N> 2. Word to PDF conversion is supported in Blazor server-side application alone and is not supported in Blazor client-side application.
-N> 3. For .NET Framework, creating an instance of the ChartToImageConverter class is mandatory to convert the charts present in the Word to PDF. Otherwise, the charts are not preserved in the converted PDF. Whereas this is not necessary for .NET Core, as ChartToImageConverter is initialized internally in Syncfusion.DocIORenderer.Portable assembly.
-N> 4. The ChartToImageConverter is supported from .NET Framework 4.0 onwards and .NET Core 2.0 onwards.
-N> 5. Total number of pages in the converted PDF may vary based on unsupported elements in the input Word document.
-N> 6. "DocIO supports Word to PDF conversion in UWP application using DocIORenderer." For further information, please refer [here](https://www.syncfusion.com/kb/10270/how-to-convert-word-document-to-pdf-in-uwp)
+N> 2. For .NET Framework, creating an instance of the ChartToImageConverter class is mandatory to convert the charts present in the Word to PDF. Otherwise, the charts are not preserved in the converted PDF. Whereas this is not necessary for .NET Core, as ChartToImageConverter is initialized internally in Syncfusion.DocIORenderer.Portable assembly.
+N> 3. The ChartToImageConverter is supported from .NET Framework 4.0 onwards and .NET Core 2.0 onwards.
+N> 4. Total number of pages in the converted PDF may vary based on unsupported elements in the input Word document.
+N> 5. "DocIO supports Word to PDF conversion in UWP application using DocIORenderer." For further information, please refer [here](https://www.syncfusion.com/kb/10270/how-to-convert-word-document-to-pdf-in-uwp)
 
 ## Word to PDF conversion in Linux OS
 

--- a/File-Formats/Presentation/Presentation-to-PDF.md
+++ b/File-Formats/Presentation/Presentation-to-PDF.md
@@ -128,11 +128,10 @@ using (FileStream fileStreamInput = new FileStream(@"Template.pptx", FileMode.Op
 
 {% endtabs %}
 
-N> 1. PowerPoint Presentation to PDF conversion is supported in Blazor server-side application alone and is not supported in Blazor client-side application. 
-N> 2. Creating an instance of [ChartToImageConverter](https://help.syncfusion.com/cr/file-formats/Syncfusion.OfficeChartToImageConverter.ChartToImageConverter.html) class is mandatory to convert the charts present in the Presentation to PDF. Otherwise, the charts are not exported to the converted PDF
-N> 3. [ChartToImageConverter](https://help.syncfusion.com/cr/file-formats/Syncfusion.OfficeChartToImageConverter.ChartToImageConverter.html) is supported from .NET Framework 4.0 onwards
-N> 4. The assembly "Syncfusion.SfChart.WPF" is non compliance with FIPS (Federal Information Processing Standard) algorithm policy.
-N> 5. **In .NET Core targeting applications**, metafile images such as EMF and WMF have some limitations. So, those images will not preserve in Presentation document to PDF conversion using Essential Presentation. 
+N> 1. Creating an instance of [ChartToImageConverter](https://help.syncfusion.com/cr/file-formats/Syncfusion.OfficeChartToImageConverter.ChartToImageConverter.html) class is mandatory to convert the charts present in the Presentation to PDF. Otherwise, the charts are not exported to the converted PDF
+N> 2. [ChartToImageConverter](https://help.syncfusion.com/cr/file-formats/Syncfusion.OfficeChartToImageConverter.ChartToImageConverter.html) is supported from .NET Framework 4.0 onwards
+N> 3. The assembly "Syncfusion.SfChart.WPF" is non compliance with FIPS (Federal Information Processing Standard) algorithm policy.
+N> 4. **In .NET Core targeting applications**, metafile images such as EMF and WMF have some limitations. So, those images will not preserve in Presentation document to PDF conversion using Essential Presentation. 
 
 N> 1. To preserve the expected images in the PDF, we suggest you convert the metafile image formats to bitmap image format (JPEG or PNG) and then perform Presentation to PDF conversion.
 N> 2. Otherwise, you can use the [WPF](https://www.nuget.org/packages/Syncfusion.PresentationToPdfConverter.Wpf/) or [Windows](https://www.nuget.org/packages/Syncfusion.PresentationToPdfConverter.WinForms/) Forms platform NuGet packages for .NET Core 3.0 or later versions targeting applications from v17.3.0.x and use the same [C# tab](https://help.syncfusion.com/file-formats/presentation/presentation-to-pdf) code examples for it. But in Mac and Linux environment, using the WPF or Windows Forms platform NuGet packages have limitations.

--- a/File-Formats/Presentation/Presentation-to-image.md
+++ b/File-Formats/Presentation/Presentation-to-image.md
@@ -344,12 +344,11 @@ pptxDoc.Close();
 
 {% endtabs %}
 
-N> 1. PowerPoint Presentation to image conversion is supported in Blazor server-side application alone and is not supported in Blazor client-side application. 
-N> 2. Instance of [ChartToImageConverter](https://help.syncfusion.com/cr/file-formats/Syncfusion.OfficeChartToImageConverter.ChartToImageConverter.html) class is mandatory to convert the charts present in the Presentation to image. Otherwise, the charts in the presentation are not exported to the converted image
-N> 3. [ChartToImageConverter](https://help.syncfusion.com/cr/file-formats/Syncfusion.OfficeChartToImageConverter.ChartToImageConverter.html) is supported from .NET Framework 4.0 onward
-N> 4. The assembly "Syncfusion.SfChart.WPF" is non compliance with FIPS(Federal Information Processing Standard) algorithm policy.
-N> 5. EMF images in the PowerPoint slides will not be converted in UWP due to platform limitation.
-N> 6. Radial gradient, rectangular gradient and path gradient brushes are not supported in UWP due to platform limitation. These brushes are rendered as linear gradient brush in our UWP slide to image conversion.
+N> 1. Instance of [ChartToImageConverter](https://help.syncfusion.com/cr/file-formats/Syncfusion.OfficeChartToImageConverter.ChartToImageConverter.html) class is mandatory to convert the charts present in the Presentation to image. Otherwise, the charts in the presentation are not exported to the converted image
+N> 2. [ChartToImageConverter](https://help.syncfusion.com/cr/file-formats/Syncfusion.OfficeChartToImageConverter.ChartToImageConverter.html) is supported from .NET Framework 4.0 onward
+N> 3. The assembly "Syncfusion.SfChart.WPF" is non compliance with FIPS(Federal Information Processing Standard) algorithm policy.
+N> 4. EMF images in the PowerPoint slides will not be converted in UWP due to platform limitation.
+N> 5. Radial gradient, rectangular gradient and path gradient brushes are not supported in UWP due to platform limitation. These brushes are rendered as linear gradient brush in our UWP slide to image conversion.
 
 ## Font substitution for unavailable fonts
 

--- a/File-Formats/Presentation/Supported-and-Unsupported-Features.md
+++ b/File-Formats/Presentation/Supported-and-Unsupported-Features.md
@@ -617,7 +617,7 @@ Yes
 Yes
 </td>
 <td>
-No
+Yes
 </td>
 <td>
 Yes
@@ -649,7 +649,7 @@ Yes
 Yes
 </td>
 <td>
-No
+Yes
 </td>
 <td>
 Yes


### PR DESCRIPTION
Kindly review the below merge request and let me know your feedback.

<table>
<tr>
<td>
Task Link
</td>
<td>
<a href="https://syncfusion.atlassian.net/browse/WF-65166">https://syncfusion.atlassian.net/browse/WF-65166</a>
</td>
</tr>
<tr>
<td>
Description
</td>
<td>
Remove note from DocIO and Presentation documentation pages.
</td>
</tr>
<tr>
<td>
Solution
</td>
<td>
Remove note regarding Word/PPTX to PDF/image not support in Blazor WASM.
</td>
</tr>
</table>

[WF-65166]: https://syncfusion.atlassian.net/browse/WF-65166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WF-65166]: https://syncfusion.atlassian.net/browse/WF-65166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ