### PR TITLE
WF-57277-Made UG changes to add missed statements

### DIFF
--- a/File-Formats/DocIO/FAQ.md
+++ b/File-Formats/DocIO/FAQ.md
@@ -2354,6 +2354,8 @@ You can download a complete working sample from [GitHub](https://github.com/Sync
 
 ## How to copy necessary Microsoft compatible fonts to Linux
 
+N> To use Microsoft fonts in your environment, kindly get license clearance from Microsoft at your side.
+
 The fonts present in the location (in Linux) "/usr/share/fonts/" is used for conversion. By default, there will be limited number of fonts available in the Linux.
 
 Use the following code example to install the Microsoft compatible fonts to Linux.

--- a/File-Formats/DocIO/FAQ.md
+++ b/File-Formats/DocIO/FAQ.md
@@ -2354,8 +2354,6 @@ You can download a complete working sample from [GitHub](https://github.com/Sync
 
 ## How to copy necessary Microsoft compatible fonts to Linux
 
-N> To use Microsoft fonts in your environment, kindly get license clearance from Microsoft at your side.
-
 The fonts present in the location (in Linux) "/usr/share/fonts/" is used for conversion. By default, there will be limited number of fonts available in the Linux.
 
 Use the following code example to install the Microsoft compatible fonts to Linux.
@@ -2369,6 +2367,8 @@ sudo apt-get install ttf-mscorefonts-installer
 {% endtabs %}
 
 After the installation, the necessary Microsoft compatible fonts will be available in this location "/usr/share/fonts/truetype/msttcorefonts", which will be considered for conversion.
+
+N> To use Microsoft fonts in your environment, kindly get license clearance from Microsoft at your side.
 
 ## How to install necessary fonts in Linux containers
 

--- a/File-Formats/DocIO/FAQ.md
+++ b/File-Formats/DocIO/FAQ.md
@@ -2368,7 +2368,7 @@ sudo apt-get install ttf-mscorefonts-installer
 
 After the installation, the necessary Microsoft compatible fonts will be available in this location "/usr/share/fonts/truetype/msttcorefonts", which will be considered for conversion.
 
-N> To use Microsoft fonts in your environment, kindly get license clearance from Microsoft at your side.
+N> To use Microsoft fonts in your environment, kindly get the license clearance from Microsoft on your side.
 
 ## How to install necessary fonts in Linux containers
 

--- a/File-Formats/DocIO/mail-merge/mail-merge-events.md
+++ b/File-Formats/DocIO/mail-merge/mail-merge-events.md
@@ -18,9 +18,7 @@ The [MailMerge](https://help.syncfusion.com/cr/file-formats/Syncfusion.DocIO.DLS
 
 * [BeforeClearGroupField](https://help.syncfusion.com/cr/file-formats/Syncfusion.DocIO.DLS.BeforeClearGroupFieldEventHandler.html)- occurs when an **unmerged group field** is encountered.
 
-## MergeField Event
-
-N> While executing mail merge, DocIO internally uses copy of particular region for populating the contents. Sometimes, it may rise unexcepted problems due to inserting multiple body items in to the region through mail merge process. So, to insert multiple body items using mergefield event handler, we recommend you to use this [How to replace merge field with HTML string using Mail merge | WinForms - DocIO](https://www.syncfusion.com/kb/11701/how-to-replace-merge-field-with-html-string-using-mail-merge) approach at your side. 
+## MergeField Event 
 
 You can apply formatting to the merged text or customize the merged text during mail merge process using the [MergeField](https://help.syncfusion.com/cr/file-formats/Syncfusion.DocIO.DLS.MergeFieldEventHandler.html) Event.
 
@@ -146,6 +144,8 @@ private void ApplyAlternateRecordsTextColor (object sender, MergeFieldEventArgs 
 {% endhighlight %}
 
 {% endtabs %}
+
+N> While executing mail merge, DocIO internally uses copy of particular region for populating the contents. Sometimes, it may rise unexcepted problems due to inserting multiple body items in to the region through mail merge process. So, to insert multiple body items using mergefield event handler, we recommend you to use this [approach](https://www.syncfusion.com/kb/11701/how-to-replace-merge-field-with-html-string-using-mail-merge) at your side.
 
 The following code example shows GetDataTable method which is used to get data for mail merge.
 

--- a/File-Formats/DocIO/mail-merge/mail-merge-events.md
+++ b/File-Formats/DocIO/mail-merge/mail-merge-events.md
@@ -20,6 +20,8 @@ The [MailMerge](https://help.syncfusion.com/cr/file-formats/Syncfusion.DocIO.DLS
 
 ## MergeField Event
 
+N> While executing mail merge, DocIO internally uses copy of particular region for populating the contents. Sometimes, it may rise unexcepted problems due to inserting multiple body items in to the region through mail merge process. So, to insert multiple body items using mergefield event handler, we recommend you to use this [How to replace merge field with HTML string using Mail merge | WinForms - DocIO](https://www.syncfusion.com/kb/11701/how-to-replace-merge-field-with-html-string-using-mail-merge) approach at your side. 
+
 You can apply formatting to the merged text or customize the merged text during mail merge process using the [MergeField](https://help.syncfusion.com/cr/file-formats/Syncfusion.DocIO.DLS.MergeFieldEventHandler.html) Event.
 
 The following code example shows how to use the [MergeField](https://help.syncfusion.com/cr/file-formats/Syncfusion.DocIO.DLS.MergeFieldEventHandler.html) event during Mail merge process.

--- a/File-Formats/DocIO/mail-merge/mail-merge-events.md
+++ b/File-Formats/DocIO/mail-merge/mail-merge-events.md
@@ -145,7 +145,7 @@ private void ApplyAlternateRecordsTextColor (object sender, MergeFieldEventArgs 
 
 {% endtabs %}
 
-N> While executing mail merge, DocIO internally uses a copy of a particular region for populating the contents. Sometimes, unexpected problems may arise due to inserting multiple body items into the region through the mail merge process. So, to insert multiple body items using the mergefield event handler, you are recommended to use this [approach](https://www.syncfusion.com/kb/11701/how-to-replace-merge-field-with-html-string-using-mail-merge) at your side.
+N> While executing mail merge, DocIO internally uses a copy of a particular region for populating the contents. Sometimes, unexpected problems may arise due to inserting multiple body items into the region through the mail merge process. So, to insert multiple body items using the merge field event handler, you are recommended to use this [approach](https://www.syncfusion.com/kb/11701/how-to-replace-merge-field-with-html-string-using-mail-merge) at your side.
 
 The following code example shows GetDataTable method which is used to get data for mail merge.
 

--- a/File-Formats/DocIO/mail-merge/mail-merge-events.md
+++ b/File-Formats/DocIO/mail-merge/mail-merge-events.md
@@ -18,7 +18,7 @@ The [MailMerge](https://help.syncfusion.com/cr/file-formats/Syncfusion.DocIO.DLS
 
 * [BeforeClearGroupField](https://help.syncfusion.com/cr/file-formats/Syncfusion.DocIO.DLS.BeforeClearGroupFieldEventHandler.html)- occurs when an **unmerged group field** is encountered.
 
-## MergeField Event 
+## MergeField Event
 
 You can apply formatting to the merged text or customize the merged text during mail merge process using the [MergeField](https://help.syncfusion.com/cr/file-formats/Syncfusion.DocIO.DLS.MergeFieldEventHandler.html) Event.
 

--- a/File-Formats/DocIO/mail-merge/mail-merge-events.md
+++ b/File-Formats/DocIO/mail-merge/mail-merge-events.md
@@ -145,7 +145,7 @@ private void ApplyAlternateRecordsTextColor (object sender, MergeFieldEventArgs 
 
 {% endtabs %}
 
-N> While executing mail merge, DocIO internally uses copy of particular region for populating the contents. Sometimes, it may rise unexcepted problems due to inserting multiple body items in to the region through mail merge process. So, to insert multiple body items using mergefield event handler, we recommend you to use this [approach](https://www.syncfusion.com/kb/11701/how-to-replace-merge-field-with-html-string-using-mail-merge) at your side.
+N> N> While executing mail merge, DocIO internally uses a copy of a particular region for populating the contents. Sometimes, unexpected problems may arise due to inserting multiple body items into the region through the mail merge process. So, to insert multiple body items using the mergefield event handler, you are recommended to use this [approach](https://www.syncfusion.com/kb/11701/how-to-replace-merge-field-with-html-string-using-mail-merge) at your side.
 
 The following code example shows GetDataTable method which is used to get data for mail merge.
 

--- a/File-Formats/DocIO/mail-merge/mail-merge-events.md
+++ b/File-Formats/DocIO/mail-merge/mail-merge-events.md
@@ -145,7 +145,7 @@ private void ApplyAlternateRecordsTextColor (object sender, MergeFieldEventArgs 
 
 {% endtabs %}
 
-N> N> While executing mail merge, DocIO internally uses a copy of a particular region for populating the contents. Sometimes, unexpected problems may arise due to inserting multiple body items into the region through the mail merge process. So, to insert multiple body items using the mergefield event handler, you are recommended to use this [approach](https://www.syncfusion.com/kb/11701/how-to-replace-merge-field-with-html-string-using-mail-merge) at your side.
+N> While executing mail merge, DocIO internally uses a copy of a particular region for populating the contents. Sometimes, unexpected problems may arise due to inserting multiple body items into the region through the mail merge process. So, to insert multiple body items using the mergefield event handler, you are recommended to use this [approach](https://www.syncfusion.com/kb/11701/how-to-replace-merge-field-with-html-string-using-mail-merge) at your side.
 
 The following code example shows GetDataTable method which is used to get data for mail merge.
 

--- a/File-Formats/DocIO/word-to-pdf.md
+++ b/File-Formats/DocIO/word-to-pdf.md
@@ -27,7 +27,7 @@ The following namespaces are required to compile the code:
 * using Syncfusion.OfficeChartToImageConverter
 * using Syncfusion.Pdf
 
-**For ASP.NET Core and Xamarin applications**
+**For ASP.NET Core,Blazor and Xamarin applications**
 * using Syncfusion.DocIO
 * using Syncfusion.DocIO.DLS
 * using Syncfusion.DocIORenderer

--- a/File-Formats/DocIO/word-to-pdf.md
+++ b/File-Formats/DocIO/word-to-pdf.md
@@ -27,7 +27,7 @@ The following namespaces are required to compile the code:
 * using Syncfusion.OfficeChartToImageConverter
 * using Syncfusion.Pdf
 
-**For ASP.NET Core,Blazor and Xamarin applications**
+**For ASP.NET Core, Blazor, Xamarin, WinUI and .NET MAUI applications**
 * using Syncfusion.DocIO
 * using Syncfusion.DocIO.DLS
 * using Syncfusion.DocIORenderer

--- a/File-Formats/DocIO/word-to-pdf.md
+++ b/File-Formats/DocIO/word-to-pdf.md
@@ -27,7 +27,7 @@ The following namespaces are required to compile the code:
 * using Syncfusion.OfficeChartToImageConverter
 * using Syncfusion.Pdf
 
-**For ASP.NET Core, Blazor, Xamarin, WinUI and .NET MAUI applications**
+**For ASP.NET Core, Blazor, Xamarin, WinUI, and .NET MAUI applications**
 * using Syncfusion.DocIO
 * using Syncfusion.DocIO.DLS
 * using Syncfusion.DocIORenderer


### PR DESCRIPTION
<table style="width: 521.306px;">
<tbody>
<tr>
<td style="width: 156px;">Task Link</td>
<td style="width: 349.306px;">(https://syncfusion.atlassian.net/browse/WF-57277)</td>
</tr>
<tr>
<td style="width: 156px;">Description</td>
<td style="width: 349.306px;">Added Blazor Server side in Word to PDF namespace list in DocIO UG</td>
</tr>
<tr>
<td style="width: 156px;">Solution</td>
<td style="width: 349.306px;">Added Blazor Server side in Word to PDF namespace list, Added license clearance information to use Microsoft fonts, Added a note in UG about how to insert multiple body items using mergefield event handler</td>
</tr>
<tr>
<td style="width: 156px;">Content review confirmation</td>
<td style="width: 349.306px;">Yes</td>
</tr>
</tbody>
</table>