### PR TITLE
EJDOTNETCORE-3866 - Add code example for flatten redaction annotation and update code for modify redaction annotation - Hotfix 

### DIFF
--- a/File-Formats/PDF/Working-with-Annotations.md
+++ b/File-Formats/PDF/Working-with-Annotations.md
@@ -784,6 +784,129 @@ else
 
 You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/PDF-Examples/tree/master/Annotation/Flatten-popup-annotation-in-the-PDF-document).
 
+### Flattening redaction annotation
+
+To flatten the redaction annotation in PDF document, use the following code example. 
+
+{% tabs %}
+
+{% highlight c# tabtitle="C#" %}
+
+//Load the existing PDF document.
+PdfLoadedDocument loadedDocument = new PdfLoadedDocument("Input.pdf");
+
+//Get the annotation from annotation collection. 
+foreach (PdfAnnotation annot in loadedDocument.Pages[0].Annotations)
+{
+    //Check for the Redaction annotation.
+    if (annot is PdfLoadedRedactionAnnotation)
+    {
+        //Get the redaction annotation. 
+        PdfLoadedRedactionAnnotation redactAnnot = annot as PdfLoadedRedactionAnnotation;
+
+        //Flatten the redaction annotation.
+        redactAnnot.Flatten = true;
+
+    }
+}
+
+//Save the document.
+loadedDocument.Save("Output.pdf");
+
+//Close the document.
+loadedDocument.Close();
+
+{% endhighlight %}
+
+{% highlight vb.net tabtitle="VB.NET" %}
+
+'Load the existing PDF document. 
+Dim loadedDocument As PdfLoadedDocument = New PdfLoadedDocument("../../Data/Input.pdf")
+
+'Get the annotation from annotation collection. 
+For Each annot As PdfAnnotation In loadedDocument.Pages(0).Annotations
+
+    'Check for redaction annotation. 
+    If TypeOf annot Is PdfLoadedRedactionAnnotation Then
+
+        'Load the redaction annotation. 
+        Dim redactAnnot As PdfLoadedRedactionAnnotation = TryCast(annot, PdfLoadedRedactionAnnotation)
+
+        'Flatten the redaction annotation.
+        redactAnnot.Flatten = True
+
+    End If
+
+Next
+
+'Save the PDF document. 
+loadedDocument.Save("Output.pdf")
+
+'Close the PDF document. 
+loadedDocument.Close()
+
+{% endhighlight %}
+
+{% highlight c# tabtitle="UWP" %}
+
+Essential PDF supports flattening redaction annotation only in Windows Forms, WPF, ASP.NET, ASP.NET MVC, and ASP.NET Core platforms.
+
+{% endhighlight %}
+
+{% highlight c# tabtitle="ASP.NET Core" %}
+
+//Get stream from an existing PDF document. 
+FileStream docStream = new FileStream("Input.pdf", FileMode.Open, FileAccess.Read);
+
+//Load the PDF document.
+PdfLoadedDocument loadedDocument = new PdfLoadedDocument(docStream);
+
+//Get the annotation from annotation collection. 
+foreach (PdfAnnotation annot in loadedDocument.Pages[0].Annotations)
+{
+    //Check for the Redaction annotation.
+    if (annot is PdfLoadedRedactionAnnotation)
+    {
+        //Get the redaction annotation. 
+        PdfLoadedRedactionAnnotation redactAnnot = annot as PdfLoadedRedactionAnnotation;
+
+        //Flatten the redaction annotation. 
+        redactAnnot.Flatten = true;
+    }
+}
+
+loadedDocument.Redact();
+
+//Save the document into stream.
+MemoryStream stream = new MemoryStream(); 
+loadedDocument.Save(stream); 
+
+stream.Position = 0; 
+
+//Close the document.
+loadedDocument.Close(true);
+
+//Defining the ContentType for PDF file.
+string contentType = "application/pdf"; 
+
+//Define the file name.
+string fileName = "output.pdf";
+
+//Create a FileContentResult object by using the file contents, content type, and file name.
+return File(stream, contentType, fileName);
+
+{% endhighlight %}
+
+{% highlight c# tabtitle="Xamarin" %}
+
+Essential PDF supports flattening redaction annotation only in Windows Forms, WPF, ASP.NET, ASP.NET MVC, and ASP.NET Core platforms.
+
+{% endhighlight %}
+
+{% endtabs %}
+
+N> To flatten the redaction annotation from PDF document in ASP.NET Core, you need to include the Syncfusion.Pdf.Imaging.Portable assembly reference in the .NET Core project. 
+
 ## Flattening annotations without calling save method 
 
 Annotations can be flattened by removing the existing annotation and replacing it with graphic objects that would resemble the annotation and cannot be edited.
@@ -1004,6 +1127,8 @@ else
 {% endtabs %}
 
 You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/PDF-Examples/tree/master/Annotation/Flattening-annotations-with-popups-in-PDF).
+
+
 
 ## Supported annotation types
 
@@ -4823,6 +4948,8 @@ redactAnnot.Flatten = true;
 }
 }
 
+loadedDocument.Redact();
+
 //Save the document into stream 
 MemoryStream stream = new MemoryStream(); 
 loadedDocument.Save(stream); 
@@ -4878,6 +5005,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("rectangleAnnotation.pd
 {% endhighlight %}
 
 {% endtabs %}
+
+N> To modify the redaction annotation from PDF document in ASP.NET Core, you need to include the Syncfusion.Pdf.Imaging.Portable assembly reference in the .NET Core project. 
 
 You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/PDF-Examples/tree/master/Annotation/Modify-the-redaction-annotation-in-PDF-document).
 


### PR DESCRIPTION
Hi All,

Kindly review the changes and let me know your feedback for the same. Please find the changes from below,
**Flattening redaction annotation**
- Added the code snippet for flattening redaction annotation in an existing PDF document.
- In ASP.NET Core platform, we need to add "loadedDocument.Redact();" code to flatten the PDF document and added this line also.
- In notes tab, added the details about assemblies required.

**Modify the redaction annotation**
To modify the redaction annotation in ASP.NET Core, we need to use "Syncfusion.Pdf.Imaging.Portable" assemblies and "loadedDocument.Redact();" code. Added this code and information in notes tab.

Regards,
Sowmiya L