### PR TITLE
EJDOTNETCORE-4045 - Add code example for flatten redaction annotation and update code for modify redaction annotation - Hotfix

### DIFF
--- a/File-Formats/PDF/Working-with-Annotations.md
+++ b/File-Formats/PDF/Working-with-Annotations.md
@@ -784,6 +784,129 @@ else
 
 You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/PDF-Examples/tree/master/Annotation/Flatten-popup-annotation-in-the-PDF-document).
 
+### Flattening redaction annotation
+
+To flatten the redaction annotation in PDF document, use the following code example. 
+
+{% tabs %}
+
+{% highlight c# tabtitle="C#" %}
+
+//Load the existing PDF document.
+PdfLoadedDocument loadedDocument = new PdfLoadedDocument("Input.pdf");
+
+//Get the annotation from annotation collection. 
+foreach (PdfAnnotation annot in loadedDocument.Pages[0].Annotations)
+{
+    //Check for the Redaction annotation.
+    if (annot is PdfLoadedRedactionAnnotation)
+    {
+        //Get the redaction annotation. 
+        PdfLoadedRedactionAnnotation redactAnnot = annot as PdfLoadedRedactionAnnotation;
+
+        //Flatten the redaction annotation.
+        redactAnnot.Flatten = true;
+
+    }
+}
+
+//Save the document.
+loadedDocument.Save("Output.pdf");
+
+//Close the document.
+loadedDocument.Close();
+
+{% endhighlight %}
+
+{% highlight vb.net tabtitle="VB.NET" %}
+
+'Load the existing PDF document. 
+Dim loadedDocument As PdfLoadedDocument = New PdfLoadedDocument("../../Data/Input.pdf")
+
+'Get the annotation from annotation collection. 
+For Each annot As PdfAnnotation In loadedDocument.Pages(0).Annotations
+
+    'Check for redaction annotation. 
+    If TypeOf annot Is PdfLoadedRedactionAnnotation Then
+
+        'Load the redaction annotation. 
+        Dim redactAnnot As PdfLoadedRedactionAnnotation = TryCast(annot, PdfLoadedRedactionAnnotation)
+
+        'Flatten the redaction annotation.
+        redactAnnot.Flatten = True
+
+    End If
+
+Next
+
+'Save the PDF document. 
+loadedDocument.Save("Output.pdf")
+
+'Close the PDF document. 
+loadedDocument.Close()
+
+{% endhighlight %}
+
+{% highlight c# tabtitle="UWP" %}
+
+Essential PDF supports flattening redaction annotation only in Windows Forms, WPF, ASP.NET, ASP.NET MVC, and ASP.NET Core platforms.
+
+{% endhighlight %}
+
+{% highlight c# tabtitle="ASP.NET Core" %}
+
+//Get stream from an existing PDF document. 
+FileStream docStream = new FileStream("Input.pdf", FileMode.Open, FileAccess.Read);
+
+//Load the PDF document.
+PdfLoadedDocument loadedDocument = new PdfLoadedDocument(docStream);
+
+//Get the annotation from annotation collection. 
+foreach (PdfAnnotation annot in loadedDocument.Pages[0].Annotations)
+{
+    //Check for the Redaction annotation.
+    if (annot is PdfLoadedRedactionAnnotation)
+    {
+        //Get the redaction annotation. 
+        PdfLoadedRedactionAnnotation redactAnnot = annot as PdfLoadedRedactionAnnotation;
+
+        //Flatten the redaction annotation. 
+        redactAnnot.Flatten = true;
+    }
+}
+
+loadedDocument.Redact();
+
+//Save the document into stream.
+MemoryStream stream = new MemoryStream(); 
+loadedDocument.Save(stream); 
+
+stream.Position = 0; 
+
+//Close the document.
+loadedDocument.Close(true);
+
+//Defining the ContentType for PDF file.
+string contentType = "application/pdf"; 
+
+//Define the file name.
+string fileName = "output.pdf";
+
+//Create a FileContentResult object by using the file contents, content type, and file name.
+return File(stream, contentType, fileName);
+
+{% endhighlight %}
+
+{% highlight c# tabtitle="Xamarin" %}
+
+Essential PDF supports flattening redaction annotation only in Windows Forms, WPF, ASP.NET, ASP.NET MVC, and ASP.NET Core platforms.
+
+{% endhighlight %}
+
+{% endtabs %}
+
+N> To flatten the redaction annotation from PDF document in ASP.NET Core, you need to include the Syncfusion.Pdf.Imaging.Portable assembly reference in the .NET Core project. 
+
 ## Flattening annotations without calling save method 
 
 Annotations can be flattened by removing the existing annotation and replacing it with graphic objects that would resemble the annotation and cannot be edited.
@@ -4823,6 +4946,8 @@ redactAnnot.Flatten = true;
 }
 }
 
+loadedDocument.Redact();
+
 //Save the document into stream 
 MemoryStream stream = new MemoryStream(); 
 loadedDocument.Save(stream); 
@@ -4878,6 +5003,8 @@ Xamarin.Forms.DependencyService.Get<ISave>().SaveAndView("rectangleAnnotation.pd
 {% endhighlight %}
 
 {% endtabs %}
+
+N> To modify the redaction annotation from PDF document in ASP.NET Core, you need to include the Syncfusion.Pdf.Imaging.Portable assembly reference in the .NET Core project. 
 
 You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/PDF-Examples/tree/master/Annotation/Modify-the-redaction-annotation-in-PDF-document).
 

--- a/File-Formats/PDF/Working-with-HyperLinks.md
+++ b/File-Formats/PDF/Working-with-HyperLinks.md
@@ -797,19 +797,43 @@ document.Close()
 
 {% highlight c# tabtitle="UWP" %}
 
-//PDF supports external document navigation only in Windows Forms, WPF, ASP.NET and ASP.NET MVC platforms.
+//PDF supports external document navigation only in Windows Forms, WPF, ASP.NET, ASP.NET MVC and ASP.NET Core platforms.
 
 {% endhighlight %}
 
 {% highlight c# tabtitle="ASP.NET Core" %}
 
-//PDF supports external document navigation only in Windows Forms, WPF, ASP.NET and ASP.NET MVC platforms.
+//Create the PDF document.
+PdfDocument document = new PdfDocument();
+//Creates a new page. 
+PdfPage page = document.Pages.Add();
+//Create a new rectangle.
+RectangleF bounds = new RectangleF(10, 40, 30, 30);
+
+//Create a link for image file. 
+PdfFileLinkAnnotation fileLinkAnnotation = new PdfFileLinkAnnotation(bounds, filePath);
+//Add this annotation to a page.
+page.Annotations.Add(fileLinkAnnotation);
+
+//Save the document into stream.
+MemoryStream stream = new MemoryStream();
+document.Save(stream);
+//Set the position as '0'.
+stream.Position = 0;
+//Close the document.
+document.Close(true);
+//Defining the ContentType for pdf file.
+string contentType = "application/pdf";
+//Define the file name.
+string fileName = "Output.pdf";
+//Creates a FileContentResult object by using the file contents, content type, and file name.
+return File(stream, contentType, fileName);
 
 {% endhighlight %}
 
 {% highlight c# tabtitle="Xamarin" %}
 
-//PDF supports external document navigation only in Windows Forms, WPF, ASP.NET and ASP.NET MVC platforms.
+//PDF supports external document navigation only in Windows Forms, WPF, ASP.NET, ASP.NET MVC and ASP.NET Core platforms.
 
 {% endhighlight %}
 

--- a/File-Formats/PDF/Working-with-forms.md
+++ b/File-Formats/PDF/Working-with-forms.md
@@ -5327,6 +5327,39 @@ loadedDocument.Close(True)
 
 {% endhighlight %}
 
+{% highlight c# tabtitle="ASP.NET Core" %}
+
+//Get stream from an existing PDF document
+FileStream docStream = new FileStream("Input.pdf", FileMode.Open, FileAccess.Read);
+
+//Load the PDF document
+PdfLoadedDocument loadedDocument = new PdfLoadedDocument(docStream);
+
+//Get stream from an existing PDF document
+FileStream fdfStream = new FileStream("ImportFDF.fdf", FileMode.Open, FileAccess.Read);
+
+//Import the FDF stream
+loadedDocument.Form.ImportDataFDF(fdfStream, true);
+
+//Save the document into stream
+MemoryStream stream = new MemoryStream();
+loadedDocument.Save(stream);
+stream.Position = 0;
+
+//Close the document
+loadedDocument.Close(true);
+
+//Defining the ContentType for pdf file
+string contentType = "application/pdf";
+
+//Define the file name
+string fileName = "Form.pdf";
+
+//Creates a FileContentResult object by using the file contents, content type, and file name
+return File(stream, contentType, fileName);
+
+{% endhighlight %}
+
 {% endtabs %}  
  
 You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/PDF-Examples/tree/master/Forms/Importing-FDF-file-to-PDF-document).
@@ -5362,6 +5395,28 @@ Dim loadedForm As PdfLoadedForm = loadedDocument.Form
 loadedForm.ExportData("Export.fdf", DataFormat.Fdf, "SourceForm.pdf")
 'Close the document
 loadedDocument.Close(True)
+
+{% endhighlight %}
+
+{% highlight c# tabtitle="ASP.NET Core" %}
+
+//Get stream from an existing PDF document
+FileStream docStream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+
+//Load the PDF document from stream
+PdfLoadedDocument loadedDocument = new PdfLoadedDocument(docStream);
+
+//Load an existing form
+PdfLoadedForm loadedForm = loadedDocument.Form;
+
+//Load the FDF file
+FileStream stream = new FileStream("Export.fdf", FileMode.Create, FileAccess.ReadWrite);
+
+//Export the existing PDF document to FDF file
+loadedForm.ExportData(stream, DataFormat.Fdf, "SourceForm.pdf");
+
+//Close the document
+loadedDocument.Close(true);
 
 {% endhighlight %}
 


### PR DESCRIPTION
Hi All,

Kindly review the changes and let me know your feedback for the same. Please find the changes from below,
**Flattening redaction annotation**
- Added the code snippet for flattening redaction annotation in an existing PDF document.
- In ASP.NET Core platform, we need to add "loadedDocument.Redact();" code to flatten the PDF document and added this line also.
- In notes tab, added the details about assemblies required.

**Modify the redaction annotation**
To modify the redaction annotation in ASP.NET Core, we need to use "Syncfusion.Pdf.Imaging.Portable" assemblies and "loadedDocument.Redact();" code. Added this code and information in notes tab.

Regards,
Sowmiya L