### PR TITLE
839188 - How to avoid ambiguous error between XlsIO.Base and XlsIO.Portable while migrating from .NET Framework to .NET Core - HF

### DIFF
--- a/File-Formats-toc.html
+++ b/File-Formats-toc.html
@@ -1033,6 +1033,7 @@
                     <li><a href="/file-formats/xlsio/faqs/why-cone-chart-shows-itself-as-colum-or-bar-chart">Why cone chart shows itself as column or bar chart</a></li>
                     <li><a href="/file-formats/xlsio/faqs/how-to-vary-colors-by-point-for-line-and-column-chart">How to vary colors by point for line and column chart</a></li>
                     <li><a href="/file-formats/xlsio/faqs/how-to-upload-a-file-to-azure-blob-and-download-as-stream">How to upload a file to Azure blob and download as stream</a></li>
+                    <li><a href="/file-formats/xlsio/faqs/avoid-ambiguous-error-while-migrating-from-net-framework-to-net-core">Avoid ambiguous error in XlsIO while migrating from .NET Framework to .NET Core</a></li>
                 </ul>
 			</li>
         </ul>

--- a/File-Formats/XlsIO/FAQ.md
+++ b/File-Formats/XlsIO/FAQ.md
@@ -79,3 +79,4 @@ The frequently asked questions in Essential XlsIO are listed below.
 * [Why cone chart shows itself as column or bar chart?](faqs/why-cone-chart-shows-itself-as-colum-or-bar-chart)
 * [How to vary colors by point for line and column chart?](faqs/how-to-vary-colors-by-point-for-line-and-column-chart)
 * [How to upload a file to Azure blob and download as stream?](faqs/how-to-upload-a-file-to-azure-blob-and-download-as-stream)
+* [Avoid ambiguous error in XlsIO while migrating from .NET Framework to .NET Core](faqs/avoid-ambiguous-error-while-migrating-from-net-framework-to-net-core)

--- a/File-Formats/XlsIO/faqs/avoid-ambiguous-error-while-migrating-from-net-framework-to-net-core.md
+++ b/File-Formats/XlsIO/faqs/avoid-ambiguous-error-while-migrating-from-net-framework-to-net-core.md
@@ -1,0 +1,29 @@
+---
+title: Avoid ambiguous error during migration | XlsIO | Syncfusion
+description: This section explains how to avoid ambiguous error while migrating Syncfusion .NET Excel (XlsIO) library from .NET Framework to .NET core.
+platform: file-formats
+control: XlsIO
+documentation: UG
+---
+
+# Avoid ambiguous error in XlsIO while migrating from .NET Framework to .NET Core
+
+While migrating from .NET Framework to .NET Core, XlsIO packages should also be changed. Please look into the below link for details.
+
+[Migrate XlsIO library from .NET Framework to .NET Core?](https://help.syncfusion.com/file-formats/xlsio/faqs/migrate-from-net-framework-to-net-core)
+
+After migration, there might be some cases in which both XlsIO.Base and XlsIO.Portable should be used. Here, an ambiguous error is thrown for having both XlsIO.Base and XlsIO.Portable in the same application. 
+
+In this case, XlsIO.Base alone can be used by changing the target framework from **net6.0** to **net6.0-windows** in **.csproj** file.
+
+{% tabs %}  
+{% highlight CSHTML %}
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net6.0-windows</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+</Project>
+{% endhighlight %}
+{% endtabs %}


### PR DESCRIPTION
Hi @Mohan2401 ,

Please review and merge the changes.

Regards,
Keerthi.