### PR TITLE
ES-818185-Added cross platform code for PPTX to Image in Presentation

### DIFF
--- a/File-Formats/Presentation/Presentation-to-image.md
+++ b/File-Formats/Presentation/Presentation-to-image.md
@@ -118,6 +118,30 @@ The following code example demonstrates the conversion of an entire Presentation
 
 {% tabs %}
 
+{% highlight c# tabtitle="C# [Cross-platform]" %}
+using (FileStream fileStream = new FileStream("Sample.pptx", FileMode.Open, FileAccess.Read))
+{
+   //Open the existing PowerPoint presentation.
+   using (IPresentation pptxDoc = Presentation.Open(fileStream))
+   {
+       //Initialize the PresentationRenderer to perform image conversion.
+       pptxDoc.PresentationRenderer = new PresentationRenderer();
+       //Convert PowerPoint to image as stream.
+       Stream[] images = pptxDoc.RenderAsImages(ExportImageFormat.Jpeg);
+       //Saves the images to file system
+       foreach (Stream stream in images)
+       {
+           //Create the output image file stream
+           using (FileStream fileStreamOutput = File.Create("Output" + Guid.NewGuid().ToString() + ".jpg"))
+           {
+               //Copy the converted image stream into created output stream
+               stream.CopyTo(fileStreamOutput);
+           }
+       }
+   }
+}
+{% endhighlight %}
+
 {% highlight c# tabtitle="C# [Windows-specific]" %}
 //Loads the PowerPoint Presentation
 IPresentation pptxDoc = Presentation.Open("Sample.pptx");
@@ -470,6 +494,40 @@ N> Font substitution for Unavailable fonts is not supported in UWP platform.
 The following code sample demonstrates how to set a substitute font for a missing font while converting a PowerPoint presentation to image.
 
 {% tabs %}
+
+{% highlight c# tabtitle="C# [Cross-platform]" %}
+//Load the PowerPoint presentation and convert to image
+using (IPresentation pptxDoc = Presentation.Open("Sample.pptx"))
+{
+    //Initialize the PresentationRenderer to perform image conversion.
+    pptxDoc.PresentationRenderer = new PresentationRenderer();
+    // Initializes the 'SubstituteFont' event to set the replacement font
+    pptxDoc.FontSettings.SubstituteFont += FontSettings_SubstituteFont;
+    //Convert PowerPoint slide to image as stream.
+    using (Stream stream = pptxDoc.Slides[0].ConvertToImage(ExportImageFormat.Jpeg))
+    {
+        //Create the output image file stream
+        using (FileStream fileStreamOutput = File.Create("Output.jpg"))
+        {
+         //Copy the converted image stream into created output stream
+         stream.CopyTo(fileStreamOutput);
+        }
+     }        
+}
+/// <summary>
+/// Sets the alternate font when a specified font is unavailable in the production environment
+/// </summary>
+/// <param name="sender">FontSettings type of the Presentation in which the specified font is used but unavailable in production environment. </param>
+/// <param name="args">Retrieves the unavailable font name and receives the substitute font name for conversion. </param>
+private static void FontSettings_SubstituteFont(object sender, SubstituteFontEventArgs args)
+{
+    if (args.OriginalFontName == "Arial Unicode MS")
+
+        args.AlternateFontName = "Arial";
+    else
+        args.AlternateFontName = "Times New Roman";
+}
+{% endhighlight %}
 
 {% highlight c# tabtitle="C# [Windows-specific]" %}
 //Load the PowerPoint presentation and convert to image


### PR DESCRIPTION
<p dir="auto">Kindly review the below pull request and let me know your feedback.</p>
<div dir="auto">
<div dir="auto">
<div dir="auto">
<table style="width: 691.052px;">
<tbody>
<tr>
<td style="width: 62px;">
<p dir="auto">Task Link</p>
</td>
<td style="width: 615.052px;">
<p dir="auto"><a href="https://dev.azure.com/EssentialStudio/Document%20Processing%20Libraries/_workitems/edit/260166">https://dev.azure.com/EssentialStudio/Document%20Processing%20Libraries/_workitems/edit/260166</a>&nbsp;</p>
</td>
</tr>
<tr>
<td style="width: 62px;">
<p dir="auto">Description</p>
</td>
<td style="width: 615.052px;">
<p dir="auto">Added the cross platform code for below samples,</p>
<ul>
<li dir="auto">PowerPoint Presentation to images</li>
<li dir="auto">Font substitution for unavailable fonts</li>
</ul>
</td>
</tr>
</tbody>
</table>
</div>
</div>
</div>