### PR TITLE
ES-259460-Add FAQ about why content control not preserving as like editable form fields in the PDF document when enabling PreserveFormFields

### DIFF
--- a/File-Formats/DocIO/FAQ.md
+++ b/File-Formats/DocIO/FAQ.md
@@ -2432,7 +2432,7 @@ RUN apt-get update -y && apt-get install libfontconfig -y
 
 * In production environment (hosted server machine), ensure whether the Visual C++ Redistributable is properly installed.
 
-    [Download](https://www.microsoft.com/en-us/download/details.aspx?id=53587) and install Visual C++, if not installed.
+    [Download](https://www.microsoft.com/en-us/download/details.aspx?id=53840) and install Visual C++, if not installed.
 
 ## How to set title when converting Word document to EPUB
 

--- a/File-Formats/DocIO/FAQ.md
+++ b/File-Formats/DocIO/FAQ.md
@@ -1,6 +1,6 @@
 ---
 title: FAQ Section | DocIO | Syncfusion
-description: Learn about the frequently asked questions in the .NET Word (DocIO) library.
+description: In this section, you can discover the various questions asked about manipulation of Word documents using the .NET Word Library (DocIO).
 platform: file-formats
 control: DocIO
 documentation: UG
@@ -2885,3 +2885,9 @@ From v20.2
 </td>
 </tr>
 </table>
+
+## Why are content controls not preserved as editable form fields in the converted PDF document even when PreserveFormFields is enabled? 
+
+Content controls behave differently from legacy form fields, such as Text, Checkbox, and Drop-down fields, during conversions to PDF format. While legacy form fields are typically preserved as editable form fields in the resulting PDF document, content controls are converted to plain text. The [PreserveFormFields](https://help.syncfusion.com/cr/file-formats/Syncfusion.DocToPDFConverter.DocToPDFConverterSettings.html#Syncfusion_DocToPDFConverter_DocToPDFConverterSettings_PreserveFormFields) API specifically retains the interactive nature of legacy form fields, not content controls.
+To ensure that form fields remain editable in the PDF converted from Word document, it is recommended to use [Text](https://help.syncfusion.com/file-formats/docio/working-with-form-fields#text-form-field), [Checkbox](https://help.syncfusion.com/file-formats/docio/working-with-form-fields#check-box), and [Drop-down](https://help.syncfusion.com/file-formats/docio/working-with-form-fields#drop-down) form fields instead of content controls in the Word document. Additionally, to preserve the form fields as editable in the resulting PDF, set the [PreserveFormFields](https://help.syncfusion.com/cr/file-formats/Syncfusion.DocToPDFConverter.DocToPDFConverterSettings.html#Syncfusion_DocToPDFConverter_DocToPDFConverterSettings_PreserveFormFields) API to true.
+You can download a complete working sample from [GitHub](https://github.com/SyncfusionExamples/DocIO-Examples/tree/main/Word-to-PDF-Conversion/Create-fillable-PDF-from-Word).


### PR DESCRIPTION
Task link - https://dev.azure.com/EssentialStudio/Document%20Processing%20Libraries/_workitems/edit/259460

Add FAQ about why content control not preserving as like editable form fields in the PDF document when enabling PreserveFormFields

Hotfix - https://github.com/syncfusion-content/fileformat-docs/pull/1916